### PR TITLE
docs(readme): link v0.3+ deferred items to tracking issues (#7, #8, #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,12 +507,12 @@ DA-chain–driven hardening across two patches (v0.1.4 + v0.2.0). No product beh
 
 The following items have explicit reopening triggers — they will move forward when the trigger fires, not on a date.
 
-- **Zod 4 migration** (split RFC: validation / execution / migration / rollback) — triggered by zod 3 EOL or v0.3.0 RFC approval. PR #6 (zod 3.25 → 4.3) was closed after a Tier 1 architecture DA chain found audit-chain hash-equality risk and `z.record` schema breaking; see PR #6 close comment for the full reasoning.
+- **Zod 4 migration** — intentionally parked until a concrete migration window opens. The migration is deferred because Zod 4 changes validation semantics that may affect audit hash stability; see PR #6 for the closing rationale.
 - **TypeScript 7.0 direct migration** — triggered by TS 7.0 RC release (skip the 6.0 transition release). PR #4 (typescript 5.9 → 6.0) was closed after a Tier 1 DA chain found tsup 8.5.1 + TS 6.0 DTS-build incompatibility on macOS via the `baseUrl` deprecation→error path.
-- **`audit_events.redaction_policy_hash`** so audit reproducibility survives redaction-policy changes (ASI06 long-tail).
-- **Provenance / SBOM publish gate** (RFC 0002) — required before npm publish; release.yml has stub stages for it.
+- **Audit reproducibility across redaction-policy changes** (`audit_events.redaction_policy_hash`, ASI06 long-tail). Tracking: #9.
+- **SBOM and provenance for release artifacts** — required before npm publish; release.yml has stub stages for it. Tracking: #8.
 - **Publish-approval gate** (release.yml stages 5–6, currently stubbed).
-- **ASI04 end-to-end DoS blocking test** (currently `[pending E2E]`).
+- **End-to-end tests proving abusive requests are actually blocked** (ASI04, currently `[pending E2E]`). Tracking: #7.
 - **`packages/web`** read-only dashboard (Vite + shadcn/ui) — slot exists but empty.
 - **Playbook CRUD in MCP** / **Incident pattern promotion via MCP** / **`POST /policies/:id` PATCH for edit-in-place**.
 - **JSONL export of audit log** for external retention.


### PR DESCRIPTION
## Summary

Link three v0.3+ deferred items in the README to newly-opened tracking issues for external visibility, and rewrite the Zod 4 line so that the closing rationale is no longer a closed-PR-comment "design of record".

| Issue | v0.3+ deferred item |
|-------|---------------------|
| #7 | ASI04 — end-to-end tests that prove abusive requests are actually blocked |
| #8 | ASI05 — SBOM + provenance for release artifacts (publish gate) |
| #9 | ASI06 long-tail — `audit_events.redaction_policy_hash` for redaction-policy reproducibility |

## Why

External readers of the v0.2.0 README cannot tell whether `[pending E2E]` / `deferred to v0.3+` items are actually being tracked or just parked indefinitely. Linking each line to an issue gives the project a single externally-visible surface for v0.3+ trigger work.

## Scope (intentionally surgical)

- **Files changed**: 1 (`README.md`, 4 lines in the `### v0.3+ (deferred / event-triggered)` section)
- **No code changes**, no migrations, no behaviour change.
- **Zod 4** line rewritten — closing rationale link to PR #6 is preserved, but no longer described as "design of record". (Closing the issue/RFC story is intentionally not a separate tracking issue; the rationale belongs to the closed PR.)
- **TypeScript 7.0 / Publish-approval gate / packages/web / Playbook CRUD / JSONL export / Plugin API / framework adapters / OWASP ASI CI** — out of scope for this PR.

## Out of scope — README.ko.md v0.3+ drift

While preparing this PR, the Korean README's `v0.3+` section was found to be already out-of-sync with the English README — the Korean side lists three different items (plugin API, framework adapters, OWASP ASI CI) and does not mention Zod 4 / TS 7.0 / ASI04 / ASI06 / SBOM at all.

This is a pre-existing drift, not introduced by this PR. Per surgical-changes discipline, this PR does not touch README.ko.md. A follow-up issue will be opened to bring the Korean v0.3+ section in line with the English one.

## Validation

- DA-chain validated (Tier 2, 3-AI: Gemini → ChatGPT → Claude Web), CRITICAL/HIGH all absorbed
- placeholder grep guard (Red-Green): `grep -nE '#N[0-9]+' README.md` returns no match (PASS)
- diff inspection: 4 + / 4 - lines, scope confined to the v0.3+ list

## Test plan

- [ ] CI green (no test changes; this is a docs-only PR so existing test suite should be untouched)
- [ ] Issue links #7 / #8 / #9 render correctly in the rendered README on this branch
- [ ] No unrelated diff (`git diff main...HEAD --stat` shows only README.md)
- [ ] (Reviewer) confirm the Zod 4 phrasing reads as "intentionally parked", not "abandoned"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
