### PR TITLE
feat(tasks): bulletin-board → gijun-AI outbox integration (P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to `gijun-ai` are documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), semver.
 
+## [0.3.1] — 2026-04-29
+
+### Context
+
+P3 of the DA-chain-agreed feature set. Adds bulletin-board → gijun-AI one-way
+outbox integration. CSR lifecycle events (create/done/error) are captured in
+bulletin-board's outbox table and forwarded to gijun-AI's new
+`POST /tasks/external` endpoint via a polling worker. Idempotent upsert ensures
+no duplicate tasks on retry. Test count: 133 (was 126).
+
+### Added
+
+- **`migrations/008_external_sync.sql`** — adds `external_id TEXT` and
+  `external_source TEXT` columns to `tasks`; partial unique index enforces one
+  task per `(external_source, external_id)` pair.
+- **`upsertExternalTask()`** (`packages/core`) — idempotent task upsert for
+  inbound events; emits `task.external_sync` audit event.
+- **`POST /tasks/external`** (`packages/server`) — REST endpoint guarded by
+  existing `requireToken` middleware; returns `201 created=true` or `200
+  created=false`.
+- **`src/db/outbox.js`** (bulletin-board) — `outbox_events` table DDL +
+  `writeOutboxEvent` / `claimPendingEvents` / `markDelivered` / `markFailed`.
+- **`scripts/outbox-worker.js`** (bulletin-board) — polling worker that
+  forwards outbox events to gijun-AI; supports `--once` and `--dry-run` flags.
+- **`scripts/csr-log.js`** hooks (bulletin-board) — silent-fail outbox writes
+  on `create-post`, `done`, and `error` commands.
+
+---
+
 ## [0.3.0] — 2026-04-29
 
 ### Context

--- a/migrations/008_external_sync.sql
+++ b/migrations/008_external_sync.sql
@@ -1,0 +1,12 @@
+-- Migration 008: External sync tracking fields for tasks
+-- Adds external_id + external_source to support inbound events from external systems
+-- (e.g., bulletin-board CSR outbox → gijun-AI task mirror)
+
+ALTER TABLE tasks ADD COLUMN external_id TEXT;
+ALTER TABLE tasks ADD COLUMN external_source TEXT;
+
+-- Unique index enforces one task per (source, external_id) pair.
+-- WHERE clause excludes rows where external_id IS NULL (regular tasks).
+CREATE UNIQUE INDEX idx_tasks_external_sync
+  ON tasks(external_source, external_id)
+  WHERE external_id IS NOT NULL;

--- a/packages/core/src/__tests__/external-sync.test.ts
+++ b/packages/core/src/__tests__/external-sync.test.ts
@@ -1,0 +1,151 @@
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolve } from 'node:path'
+
+process.env['GIJUN_DB_PATH'] = ':memory:'
+process.env['GIJUN_MIGRATIONS_PATH'] = resolve(__dirname, '../../../../migrations')
+
+import { runMigrations, closeDb, getDb } from '../db/client.js'
+import {
+  upsertExternalTask,
+  getTask,
+} from '../task/service.js'
+import { tailAuditEvents } from '../audit/service.js'
+
+before(() => { runMigrations() })
+after(() => {
+  closeDb()
+  delete process.env['GIJUN_DB_PATH']
+  delete process.env['GIJUN_MIGRATIONS_PATH']
+})
+
+// ---------------------------------------------------------------------------
+// upsertExternalTask: 기본 생성
+// ---------------------------------------------------------------------------
+
+test('upsertExternalTask: creates task with external tracking fields', () => {
+  const result = upsertExternalTask({
+    externalSource: 'bulletin-board-csr',
+    externalId: 'csr-101',
+    title: '[CSR #101] 새 기능 요청',
+  })
+  assert.ok(result.id > 0)
+  assert.equal(result.created, true)
+
+  const row = getTask(result.id)
+  assert.ok(row)
+  assert.equal(row.title, '[CSR #101] 새 기능 요청')
+  assert.equal(row.status, 'pending')
+})
+
+test('upsertExternalTask: stores external_id and external_source', () => {
+  const result = upsertExternalTask({
+    externalSource: 'bulletin-board-csr',
+    externalId: 'csr-102',
+    title: '[CSR #102] 테스트',
+  })
+  const db = getDb()
+  const row = db.prepare(
+    'SELECT external_id, external_source FROM tasks WHERE id = ?'
+  ).get(result.id) as { external_id: string; external_source: string }
+  assert.equal(row.external_id, 'csr-102')
+  assert.equal(row.external_source, 'bulletin-board-csr')
+})
+
+// ---------------------------------------------------------------------------
+// upsertExternalTask: 멱등성 (idempotency)
+// ---------------------------------------------------------------------------
+
+test('upsertExternalTask: same externalId returns existing task (no duplicate)', () => {
+  const first = upsertExternalTask({
+    externalSource: 'bulletin-board-csr',
+    externalId: 'csr-201',
+    title: '원본 제목',
+  })
+  const second = upsertExternalTask({
+    externalSource: 'bulletin-board-csr',
+    externalId: 'csr-201',
+    title: '원본 제목',
+  })
+  assert.equal(second.id, first.id)
+  assert.equal(second.created, false)
+
+  const db = getDb()
+  const count = (db.prepare(
+    "SELECT COUNT(*) as cnt FROM tasks WHERE external_id = 'csr-201'"
+  ).get() as { cnt: number }).cnt
+  assert.equal(count, 1)
+})
+
+// ---------------------------------------------------------------------------
+// upsertExternalTask: 상태 업데이트
+// ---------------------------------------------------------------------------
+
+test('upsertExternalTask: updates status when called with new status', () => {
+  const { id } = upsertExternalTask({
+    externalSource: 'bulletin-board-csr',
+    externalId: 'csr-301',
+    title: '[CSR #301] 상태 변경 테스트',
+  })
+  assert.equal(getTask(id)!.status, 'pending')
+
+  upsertExternalTask({
+    externalSource: 'bulletin-board-csr',
+    externalId: 'csr-301',
+    title: '[CSR #301] 상태 변경 테스트',
+    status: 'done',
+  })
+  assert.equal(getTask(id)!.status, 'done')
+})
+
+test('upsertExternalTask: pending→cancelled transition works', () => {
+  const { id } = upsertExternalTask({
+    externalSource: 'bulletin-board-csr',
+    externalId: 'csr-302',
+    title: '[CSR #302] 취소 테스트',
+  })
+  upsertExternalTask({
+    externalSource: 'bulletin-board-csr',
+    externalId: 'csr-302',
+    title: '[CSR #302] 취소 테스트',
+    status: 'cancelled',
+  })
+  assert.equal(getTask(id)!.status, 'cancelled')
+})
+
+// ---------------------------------------------------------------------------
+// audit event
+// ---------------------------------------------------------------------------
+
+test('upsertExternalTask: emits task.external_sync audit event on create', () => {
+  const { id } = upsertExternalTask({
+    externalSource: 'bulletin-board-csr',
+    externalId: 'csr-401',
+    title: '[CSR #401] 감사 이벤트 테스트',
+  })
+  const events = tailAuditEvents(5) as { event_type: string; resource_id: string }[]
+  const event = events.find(
+    e => e.event_type === 'task.external_sync' && e.resource_id === String(id)
+  )
+  assert.ok(event, 'task.external_sync audit event must be emitted')
+})
+
+// ---------------------------------------------------------------------------
+// different externalSource — should create separate tasks
+// ---------------------------------------------------------------------------
+
+test('upsertExternalTask: same externalId from different source creates separate tasks', () => {
+  const a = upsertExternalTask({
+    externalSource: 'source-a',
+    externalId: 'shared-id-1',
+    title: 'Task from source A',
+  })
+  const b = upsertExternalTask({
+    externalSource: 'source-b',
+    externalId: 'shared-id-1',
+    title: 'Task from source B',
+  })
+  assert.notEqual(a.id, b.id)
+  assert.equal(a.created, true)
+  assert.equal(b.created, true)
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,8 +11,10 @@ export type { CostEntry, ParseStatus, CostSource, ICostParser, IPricingStrategy,
 export { createPlaybook, updatePlaybook, listPlaybooks, getPlaybook } from './playbook/service.js'
 
 export {
-  createTask, updateTaskStatus, approveHitl, addTaskStep, listTasks, getTask
+  createTask, updateTaskStatus, approveHitl, addTaskStep, listTasks, getTask,
+  upsertExternalTask, ExternalTaskSchema,
 } from './task/service.js'
+export type { ExternalTaskInput } from './task/service.js'
 
 export {
   searchKnowledge, createKnowledgeItem, promoteCandidate, listKnowledge,

--- a/packages/core/src/task/service.ts
+++ b/packages/core/src/task/service.ts
@@ -181,3 +181,71 @@ export function listTasks(opts: { project?: string; status?: string; limit?: num
 export function getTask(id: number): TaskRow | undefined {
   return getDb().prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow | undefined
 }
+
+export const ExternalTaskSchema = z.object({
+  externalSource: z.string().min(1).max(128),
+  externalId: z.string().min(1).max(256),
+  title: z.string().min(1).max(512),
+  description: z.string().max(4096).optional(),
+  status: z.enum(['pending', 'in_progress', 'done', 'cancelled']).optional(),
+})
+
+export type ExternalTaskInput = z.input<typeof ExternalTaskSchema>
+
+/**
+ * Upsert a task from an external system (e.g., bulletin-board CSR outbox).
+ * Idempotent: same (externalSource, externalId) pair always maps to the same task row.
+ * Returns { id, created: true } on first insert, { id, created: false } on subsequent calls.
+ */
+export function upsertExternalTask(input: ExternalTaskInput): { id: number; created: boolean } {
+  const validated = ExternalTaskSchema.parse(input)
+  const db = getDb()
+
+  const existing = db.prepare(
+    'SELECT id FROM tasks WHERE external_source = ? AND external_id = ?'
+  ).get(validated.externalSource, validated.externalId) as { id: number } | undefined
+
+  if (existing) {
+    const newStatus = validated.status
+    if (newStatus !== undefined) {
+      withTxAndAudit<void>(txDb => {
+        txDb.prepare(
+          "UPDATE tasks SET status = ?, updated_at = datetime('now') WHERE id = ?"
+        ).run(newStatus, existing.id)
+        const audit: AuditEventInput = {
+          eventType: 'task.external_sync',
+          action: `external sync: ${validated.externalSource}/${validated.externalId} → status=${newStatus}`,
+          resourceType: 'task',
+          resourceId: String(existing.id),
+          payload: { externalSource: validated.externalSource, externalId: validated.externalId, status: newStatus },
+        }
+        return { result: undefined, audit }
+      })
+    }
+    return { id: existing.id, created: false }
+  }
+
+  const id = withTxAndAudit<number>(txDb => {
+    const result = txDb.prepare(`
+      INSERT INTO tasks
+        (title, description, complexity, external_source, external_id, status)
+      VALUES (?, ?, 'standard', ?, ?, 'pending')
+    `).run(
+      validated.title,
+      validated.description ?? null,
+      validated.externalSource,
+      validated.externalId,
+    )
+    const newId = result.lastInsertRowid as number
+    const audit: AuditEventInput = {
+      eventType: 'task.external_sync',
+      action: `external task created: ${validated.externalSource}/${validated.externalId}`,
+      resourceType: 'task',
+      resourceId: String(newId),
+      payload: { externalSource: validated.externalSource, externalId: validated.externalId, created: true },
+    }
+    return { result: newId, audit }
+  })
+
+  return { id, created: true }
+}

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -1,6 +1,6 @@
 import { Router, type RequestHandler } from 'express'
 import { z } from 'zod'
-import { createTask, getTask, updateTaskStatus, listTasks, addTaskStep, approveHitl, LIST_MAX_LIMIT } from '@gijun-ai/core'
+import { createTask, getTask, updateTaskStatus, listTasks, addTaskStep, approveHitl, upsertExternalTask, LIST_MAX_LIMIT } from '@gijun-ai/core'
 import { requireToken } from '../middleware/auth.js'
 
 export const tasksRouter: ReturnType<typeof Router> = Router()
@@ -94,8 +94,25 @@ const hitlApproveHandler: RequestHandler = (req, res, next) => {
   } catch (err) { next(err) }
 }
 
+const ExternalSyncBody = z.object({
+  externalSource: z.string().min(1).max(128),
+  externalId: z.string().min(1).max(256),
+  title: z.string().min(1).max(512),
+  description: z.string().max(4096).optional(),
+  status: z.enum(['pending', 'in_progress', 'done', 'cancelled']).optional(),
+})
+
+const externalSyncHandler: RequestHandler = (req, res, next) => {
+  try {
+    const body = ExternalSyncBody.parse(req.body ?? {})
+    const result = upsertExternalTask(body)
+    res.status(result.created ? 201 : 200).json(result)
+  } catch (err) { next(err) }
+}
+
 tasksRouter.get('/', requireToken, listHandler)
 tasksRouter.post('/', requireToken, createHandler)
+tasksRouter.post('/external', requireToken, externalSyncHandler)
 tasksRouter.get('/:id', requireToken, getHandler)
 tasksRouter.patch('/:id/status', requireToken, updateStatusHandler)
 tasksRouter.post('/:id/steps', requireToken, addStepHandler)

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -14,7 +14,7 @@ const HOST = '127.0.0.1'  // local-only by design (contract #5)
 runMigrations()
 
 // Verify full migration chain before accepting requests (contract #2).
-assertSchemaChain(['001_initial', '002_original_hash', '003_original_hash_type', '004_cost_budget', '005_policy_eval_index', '006_cost_parse_status', '007_knowledge_status'])
+assertSchemaChain(['001_initial', '002_original_hash', '003_original_hash_type', '004_cost_budget', '005_policy_eval_index', '006_cost_parse_status', '007_knowledge_status', '008_external_sync'])
 
 process.on('exit', () => closeDb())
 


### PR DESCRIPTION
## Summary

- Adds `POST /tasks/external` endpoint (idempotent upsert by `externalSource` + `externalId`)
- `migrations/008_external_sync.sql`: `external_id`, `external_source` columns + partial unique index on `tasks`
- `upsertExternalTask()` in `@gijun-ai/core` with `task.external_sync` audit event
- 7 new tests in `external-sync.test.ts` (create, idempotency, status update, audit, cross-source isolation)
- bulletin-board side: `src/db/outbox.js`, `scripts/outbox-worker.js`, `csr-log.js` hooks (separate repo PR)

## Security

- Endpoint protected by existing `requireToken` (Bearer) middleware
- All inputs validated with Zod schema (min/max bounds)
- No hardcoded credentials — `GIJUN_AI_TOKEN` env var only

## Test plan

- [x] `pnpm build` — exit 0 (all 3 packages)
- [x] `pnpm test` — 133 pass / 0 fail (core 103, mcp-server 22, server 8)
- [x] `pnpm sync:readme:check` — README is in sync (4 patterns)
- [x] Security pipeline: CWE-287/89/20/918/798 — no CRITICAL/HIGH findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)