### PR TITLE
security: expand redaction patterns, add backup script, block HITL self-approval via MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist-test
 *.db-wal
 .DS_Store
 prompt_plan.md
+
+# backup script output
+backups/

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Each ASI claim below carries a verification label so readers know which claims a
 ### ASI06 — Sensitive Information Disclosure
 
 **Countermeasure**: redaction via `payload` blank + `original_hash` preservation. Subject-access-rights requests can blank PII without breaking the audit chain.
-**Scope (honest)**: `redactPayload` matches **4 patterns** at the time of writing: `sk-…`, `sk-ant-…`, `Bearer …`, `ghp_…` (see `audit/service.ts:7-12`). It does **not** match AWS access keys (`AKIA…`), GCP API keys, Stripe `sk_live_…`, Slack tokens (`xoxb-…`), JWTs, OpenAI Project keys, or PII (emails, phone numbers, KR resident IDs). Externalising the pattern set is partially complete: v0.2.0 introduced [`docs/audit-event-schema.md`](./docs/audit-event-schema.md) (SSOT for the `audit_events` table shape, hash-chain semantics, and redaction contract) and `pnpm sync:readme` (regenerator that pins the pattern table below to `packages/core/src/audit/service.ts`). Adding `audit_events.redaction_policy_hash` so audit reproducibility survives policy changes is deferred to v0.3+. Until then, broader redaction is the operator's responsibility — see [`docs/legal.md`](./docs/legal.md).
+**Scope (honest)**: `redactPayload` matches **8 patterns**: `sk-…`, `sk-ant-…`, `Bearer …`, `ghp_…`, AWS Access Key ID (`AKIA`/`ASIA`), AWS Secret Key (keyword-context), GCP private key (PEM block), Azure Storage Account Key (see `audit/service.ts`). It does **not** match AWS Secret Key without keyword context (false-positive risk), Stripe `sk_live_…`, Slack tokens (`xoxb-…`), JWTs, or PII (emails, phone numbers, KR resident IDs). Externalising the pattern set is partially complete: v0.2.0 introduced [`docs/audit-event-schema.md`](./docs/audit-event-schema.md) (SSOT for the `audit_events` table shape, hash-chain semantics, and redaction contract) and `pnpm sync:readme` (regenerator that pins the pattern table below to `packages/core/src/audit/service.ts`). Adding `audit_events.redaction_policy_hash` so audit reproducibility survives policy changes is deferred to v0.3+. Until then, broader redaction is the operator's responsibility — see [`docs/legal.md`](./docs/legal.md).
 **Modules**: `packages/core/src/audit/service.ts` (`redactPayload`)
 
 **Pattern table (kept in sync with code via `pnpm sync:readme`):**
@@ -456,6 +456,10 @@ Each ASI claim below carries a verification label so readers know which claims a
 | 2 | `/sk-ant-[A-Za-z0-9_-]{20,}/` | — |
 | 3 | `/Bearer\s+[A-Za-z0-9._-]{20,}/` | — |
 | 4 | `/ghp_[A-Za-z0-9]{36}/` | GitHub personal access tokens |
+| 5 | `/(?:AKIA\|ASIA)[0-9A-Z]{16}/` | AWS Access Key ID (long-term + STS temporary) |
+| 6 | `/(?:aws_?secret\|secret_?access_?key)\s*[=:"'\s]+[A-Za-z0-9/+=]{40}/i` | AWS Secret Key (keyword context) |
+| 7 | `/-----BEGIN(?:\s+[A-Z]+)?\s+PRIVATE KEY-----/i` | GCP private key PEM block |
+| 8 | `/AccountKey=[A-Za-z0-9+\/]{86}==/` | Azure Storage Account Key |
 
 <!-- generated:asi06-patterns:end -->
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "sync:readme": "node scripts/sync-readme.mjs",
     "sync:readme:check": "node scripts/sync-readme.mjs --check",
     "verify:audit-schema": "node scripts/verify-audit-schema.mjs",
+    "backup": "node scripts/backup.mjs",
+    "approve-hitl": "node scripts/approve-hitl.mjs",
     "test": "pnpm -r test"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/redaction-boundary.test.ts
+++ b/packages/core/src/__tests__/redaction-boundary.test.ts
@@ -1,12 +1,13 @@
 // ASI06 redaction boundary test — pins the README claim in code.
 // Covers 5 boundary paths: input / output / log / exception stack / audit event.
-// Reference: README ASI06, prompt_plan.md Phase 5.
+// Reference: README ASI06, prompt_plan.md.
 //
-// Scope is intentionally narrow (matches README): the 4 patterns
-// `sk-…`, `sk-ant-…`, `Bearer …`, `ghp_…`. Patterns explicitly NOT
-// covered (AWS / GCP / Stripe / Slack / JWT / PII) are exercised here
-// with negative assertions so the README scope ↔ code scope link is
-// machine-checked.
+// Scope (8 patterns): OpenAI · Anthropic · Bearer · GitHub PAT ·
+//   AWS Access Key (AKIA/ASIA) · AWS Secret Key (keyword-context) ·
+//   GCP private key (PEM block) · Azure Storage Account Key
+// Patterns explicitly NOT covered (Stripe / Slack / JWT / PII / standalone
+// 40-char Base64) are exercised with negative assertions so the README
+// scope ↔ code scope link is machine-checked.
 
 import { resolve } from 'node:path'
 
@@ -22,19 +23,30 @@ import { redactPayload, appendAuditEvent, tailAuditEvents } from '../audit/servi
 // --- Fixture patterns ----------------------------------------------
 // Each pattern is paired with one secret string that should match.
 const COVERED = {
-  openai: `sk-proj-${'a'.repeat(40)}`,
-  anthropic: `sk-ant-api03-${'b'.repeat(40)}`,
-  bearer: `Bearer ${'c'.repeat(40)}`,
-  github_pat: `ghp_${'D'.repeat(36)}`,
+  // original 4
+  openai:      `sk-proj-${'a'.repeat(40)}`,
+  anthropic:   `sk-ant-api03-${'b'.repeat(40)}`,
+  bearer:      `Bearer ${'c'.repeat(40)}`,
+  github_pat:  `ghp_${'D'.repeat(36)}`,
+  // AWS
+  aws_akia:    'AKIAIOSFODNN7EXAMPLE',
+  aws_asia:    'ASIAIOSFODNN7EXAMPLE',
+  aws_secret:  `aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`,
+  // GCP
+  gcp_pem:     '-----BEGIN RSA PRIVATE KEY-----',
+  gcp_pem_ec:  '-----BEGIN EC PRIVATE KEY-----',
+  // Azure
+  azure_key:   `AccountKey=${'a'.repeat(86)}==`,
 }
 
 // Patterns README claims are NOT covered. Used for negative assertions.
 const NOT_COVERED = {
-  aws: 'AKIAIOSFODNN7EXAMPLE',
-  stripe: `sk_live_${'e'.repeat(24)}`,
+  // AWS Secret Key without keyword context — false-positive risk too high
+  aws_secret_no_ctx: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  stripe:    `sk_live_${'e'.repeat(24)}`,
   slack_bot: `xoxb-${'1'.repeat(11)}-${'2'.repeat(11)}-${'a'.repeat(24)}`,
-  jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature',
-  email: 'alice@example.com',
+  jwt:       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature',
+  email:     'alice@example.com',
 }
 
 const REDACTED = '[REDACTED]'

--- a/packages/core/src/audit/service.ts
+++ b/packages/core/src/audit/service.ts
@@ -4,11 +4,24 @@ import { computeContentHash, computeChainHash, getGenesisHash } from './chain.js
 
 // Patterns that match common API key / token formats.
 // Applied to string values inside payload before storage.
+// Scope (8 patterns): OpenAI · Anthropic · Bearer · GitHub PAT ·
+//   AWS Access Key (AKIA/ASIA) · AWS Secret Key (keyword-context) ·
+//   GCP private key (PEM block) · Azure Storage Account Key
+// NOT covered (false-positive risk): standalone 40-char Base64, Stripe,
+//   Slack bot token, JWT, PII — tracked in v0.2 roadmap.
 const REDACT_PATTERNS: RegExp[] = [
+  // ── existing 4 ──────────────────────────────────────────────────
   /sk-[A-Za-z0-9_-]{20,}/g,
   /sk-ant-[A-Za-z0-9_-]{20,}/g,
   /Bearer\s+[A-Za-z0-9._-]{20,}/gi,
-  /ghp_[A-Za-z0-9]{36}/g,          // GitHub personal access tokens
+  /ghp_[A-Za-z0-9]{36}/g,
+  // ── AWS ─────────────────────────────────────────────────────────
+  /(?:AKIA|ASIA)[0-9A-Z]{16}/g,                              // Access Key ID (long-term + STS temporary)
+  /(?:aws_?secret|secret_?access_?key)\s*[=:"'\s]+[A-Za-z0-9/+=]{40}/gi, // Secret Key (keyword context)
+  // ── GCP ─────────────────────────────────────────────────────────
+  /-----BEGIN(?:\s+[A-Z]+)?\s+PRIVATE KEY-----/gi,           // PEM block header (JSON/YAML/env-var agnostic)
+  // ── Azure ───────────────────────────────────────────────────────
+  /AccountKey=[A-Za-z0-9+/]{86}==/g,                        // Storage Account Key (88-char Base64, always ==)
 ]
 const REDACTED_PLACEHOLDER = '[REDACTED]'
 

--- a/packages/mcp-server/src/__tests__/tools-registry.test.ts
+++ b/packages/mcp-server/src/__tests__/tools-registry.test.ts
@@ -13,8 +13,17 @@ function classify(name: string): 'read' | 'write' | 'unknown' {
   return 'unknown'
 }
 
-test('tools-registry: TOOLS length is exactly 23 (READ 10 + WRITE 13)', () => {
-  assert.equal(TOOLS.length, 23)
+test('tools-registry: TOOLS length is exactly 22 (READ 10 + WRITE 12)', () => {
+  // approve_hitl removed from MCP tools — human approval must use REST API / pnpm approve-hitl
+  assert.equal(TOOLS.length, 22)
+})
+
+test('tools-registry: approve_hitl is absent (MCP self-approval prevention)', () => {
+  const names = TOOLS.map(t => t.name)
+  assert.ok(
+    !names.includes('approve_hitl'),
+    'approve_hitl must not be accessible via MCP to prevent agent self-approval',
+  )
 })
 
 test('tools-registry: every tool name is unique', () => {
@@ -66,7 +75,7 @@ test('tools-registry: 10 READ tools and 13 WRITE tools by prefix policy', () => 
   const reads = TOOLS.filter(t => classify(t.name) === 'read')
   const writes = TOOLS.filter(t => classify(t.name) === 'write')
   assert.equal(reads.length, 10, '10 READ tools expected')
-  assert.equal(writes.length, 13, '13 WRITE tools expected')
+  assert.equal(writes.length, 12, '12 WRITE tools expected (approve_hitl removed)')
 })
 
 test('tools-registry: every WRITE tool description contains "WRITES"', () => {

--- a/packages/mcp-server/src/__tests__/tools-zod-negative.test.ts
+++ b/packages/mcp-server/src/__tests__/tools-zod-negative.test.ts
@@ -65,10 +65,7 @@ const INVALID: Record<string, InvalidCase[]> = {
     { name: 'missing stepNo', input: { id: 1 }, reason: 'stepNo required' },
     { name: 'stepNo zero', input: { id: 1, stepNo: 0 }, reason: 'stepNo min(1)' },
   ],
-  approve_hitl: [
-    { name: 'missing id', input: {}, reason: 'id required' },
-    { name: 'id string', input: { id: 'abc' }, reason: 'id must be int' },
-  ],
+  // approve_hitl removed from MCP — no INVALID entry needed
   append_audit: [
     { name: 'missing fields', input: {}, reason: 'eventType+action required' },
     { name: 'missing action', input: { eventType: 'x' }, reason: 'action required' },

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -99,8 +99,6 @@ const AddTaskStepSchema = z.object({
   latencyMs: z.number().int().optional(),
 })
 
-const ApproveHitlSchema = z.object({ id: z.number().int() })
-
 const AppendAuditSchema = z.object({
   eventType: z.string().min(1),
   action: z.string().min(1),
@@ -215,8 +213,13 @@ export const TOOLS: ToolDef[] = [
       const { id, ...body } = a
       return c.post(`/tasks/${id}/steps`, body)
     }),
-  def('approve_hitl', 'Record a human approval for a HITL-gated task. WRITES to DB.', ApproveHitlSchema,
-    (a, c) => c.post(`/tasks/${a.id}/hitl-approve`)),
+  // approve_hitl is intentionally absent from MCP tools.
+  // Approving a HITL gate via the same channel the agent uses would let the agent
+  // self-approve, defeating the gate's purpose. Human approval must come through a
+  // separate path: REST API directly, or `pnpm approve-hitl <id>`.
+  // Scope: this removes only the MCP path. An agent with shell access and the token
+  // could still call the REST endpoint directly — this is an accepted residual risk
+  // for a single-user local tool. Multi-user deployments should use token separation.
   def('append_audit', 'Append an immutable audit event to the hash chain. WRITES to DB.', AppendAuditSchema,
     (a, c) => c.post('/audit', a)),
   def('create_knowledge', 'Create a knowledge-store item in a specific layer. WRITES to DB.', CreateKnowledgeSchema,

--- a/scripts/approve-hitl.mjs
+++ b/scripts/approve-hitl.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Human-only HITL approval helper.
+// Usage: node scripts/approve-hitl.mjs <task-id>
+//
+// Intentionally kept out of MCP tools so agents cannot call it automatically.
+// Env: AGENTGUARD_TOKEN, AGENTGUARD_HOST (default: http://localhost:3456)
+
+import { createInterface } from 'node:readline'
+
+const [,, rawId] = process.argv
+const id = parseInt(rawId, 10)
+
+if (!rawId || Number.isNaN(id) || id < 1) {
+  console.error('Usage: node scripts/approve-hitl.mjs <task-id>')
+  process.exit(1)
+}
+
+const token = process.env['AGENTGUARD_TOKEN']
+if (!token) {
+  console.error('approve-hitl: AGENTGUARD_TOKEN not set')
+  process.exit(1)
+}
+
+const host = process.env['AGENTGUARD_HOST'] ?? 'http://localhost:3456'
+
+// Confirm before approving
+const rl = createInterface({ input: process.stdin, output: process.stdout })
+rl.question(`Approve HITL gate for task #${id}? [y/N] `, async (answer) => {
+  rl.close()
+  if (answer.toLowerCase() !== 'y') {
+    console.log('Aborted.')
+    process.exit(0)
+  }
+
+  const res = await fetch(`${host}/tasks/${id}/hitl-approve`, {
+    method: 'POST',
+    headers: { 'X-AgentGuard-Token': token },
+  })
+
+  if (res.ok) {
+    console.log(`✓ Task #${id} HITL approved`)
+  } else {
+    const body = await res.text().catch(() => '')
+    console.error(`✗ Failed (${res.status}): ${body}`)
+    process.exit(1)
+  }
+})

--- a/scripts/backup.mjs
+++ b/scripts/backup.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Backup gijun.db using SQLite VACUUM INTO (safe online backup, WAL-aware).
+// Creates a date-stamped copy and a chain_hash checkpoint for integrity spot-checks.
+//
+// Usage:  node scripts/backup.mjs [--keep N] [--dest DIR]
+//   --keep N   Keep the N most recent backup files (default: 7). Older ones are pruned.
+//   --dest DIR Directory to write backups into    (default: ./backups)
+//
+// Env:
+//   AGENTGUARD_DB_PATH | GIJUN_DB_PATH   Path to gijun.db (fallback: ./gijun.db)
+//   DB resolution order: AGENTGUARD_DB_PATH → GIJUN_DB_PATH → ./gijun.db
+//
+// Outputs (per run):
+//   {dest}/gijun-backup-YYYY-MM-DD.db      — consistent SQLite snapshot (overwritten if same day)
+//   {dest}/gijun-chain-checkpoint.json     — last 50 chain_hash entries for integrity spot-checks
+//
+// Restore: copy gijun-backup-YYYY-MM-DD.db to the original DB path.
+//   Verify chain integrity after restore: pnpm audit:verify
+//
+// Note: scheduling (e.g. daily cron) is the operator's responsibility.
+//   Cron example: 0 2 * * *  cd /path/to/gijun-ai && /usr/local/bin/node scripts/backup.mjs
+
+import { existsSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { join, resolve } from 'node:path'
+
+// ── CLI args ────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2)
+const keepIdx  = args.indexOf('--keep')
+const destIdx  = args.indexOf('--dest')
+const keepFiles = keepIdx >= 0 ? parseInt(args[keepIdx + 1], 10) : 7
+const destDir   = destIdx >= 0 ? args[destIdx + 1] : './backups'
+
+if (Number.isNaN(keepFiles) || keepFiles < 1) {
+  console.error('backup: --keep must be a positive integer')
+  process.exit(1)
+}
+
+// ── DB path ─────────────────────────────────────────────────────────────────
+const dbPath = process.env['AGENTGUARD_DB_PATH']
+  ?? process.env['GIJUN_DB_PATH']
+  ?? './gijun.db'
+
+if (!existsSync(dbPath)) {
+  console.error(`backup: DB not found at ${resolve(dbPath)}`)
+  process.exit(1)
+}
+
+mkdirSync(destDir, { recursive: true })
+
+// ── 1. Online backup via VACUUM INTO ────────────────────────────────────────
+// VACUUM INTO is WAL-aware and produces a consistent single-file snapshot
+// without requiring an exclusive lock on the source database.
+const today    = new Date().toISOString().slice(0, 10)
+const destFile = join(destDir, `gijun-backup-${today}.db`)
+
+const db = new DatabaseSync(dbPath)
+try {
+  db.exec(`VACUUM INTO '${destFile.replace(/'/g, "''")}'`)
+  console.log(`✓ backup: ${destFile}`)
+} finally {
+  db.close()
+}
+
+// ── 2. chain_hash checkpoint ─────────────────────────────────────────────────
+// Reads from the freshly-created backup (not the live DB) to avoid contention.
+const backupDb = new DatabaseSync(destFile)
+let hashes
+try {
+  hashes = backupDb.prepare(
+    'SELECT id, chain_hash, created_at FROM audit_events ORDER BY id DESC LIMIT 50'
+  ).all()
+} catch {
+  hashes = []
+  console.warn('backup: audit_events table not found — checkpoint skipped (DB may be uninitialized)')
+} finally {
+  backupDb.close()
+}
+
+const checkpointFile = join(destDir, 'gijun-chain-checkpoint.json')
+writeFileSync(
+  checkpointFile,
+  JSON.stringify({ updatedAt: new Date().toISOString(), source: destFile, hashes }, null, 2)
+)
+console.log(`✓ checkpoint: ${checkpointFile} (${hashes.length} entries)`)
+
+// ── 3. Prune old backups ─────────────────────────────────────────────────────
+const BACKUP_RE = /^gijun-backup-\d{4}-\d{2}-\d{2}\.db$/
+const allBackups = readdirSync(destDir)
+  .filter(f => BACKUP_RE.test(f))
+  .sort()  // lexicographic = chronological for YYYY-MM-DD
+
+const excess = allBackups.slice(0, Math.max(0, allBackups.length - keepFiles))
+for (const f of excess) {
+  try {
+    unlinkSync(join(destDir, f))
+    console.log(`✓ pruned: ${f}`)
+  } catch (err) {
+    console.warn(`backup: failed to prune ${f}: ${err.message}`)
+  }
+}
+
+console.log(
+  `backup complete — kept=${Math.min(allBackups.length, keepFiles)} pruned=${excess.length}`
+)


### PR DESCRIPTION
## Summary

- **H-3**: Expand `REDACT_PATTERNS` from 4 → 8 to cover AWS Access Key ID (AKIA/ASIA), AWS Secret Key (keyword-context), GCP private key (PEM block), and Azure Storage Account Key. Tests and README updated to reflect new scope.
- **H-2**: Add `scripts/backup.mjs` using SQLite `VACUUM INTO` for WAL-safe online backup, plus a `chain_hash` checkpoint JSON. `pnpm backup` script entry added; `backups/` added to `.gitignore`.
- **H-1**: Remove `approve_hitl` from the MCP tool registry so agents cannot self-approve HITL gates via MCP. Document residual risk (agent with shell + token can still call REST directly). Add `scripts/approve-hitl.mjs` as a human-only CLI helper (`pnpm approve-hitl <id>`).

All three items were DA-verified (Gemini + ChatGPT + Claude Web) before implementation.

## Test plan

- [x] `pnpm test` → 134/134 pass (core 103, mcp-server 23, server 8), 0 fail
- [x] `pnpm lint` → 0 warnings, 0 errors
- [x] `pnpm backup` smoke-tested against live `gijun.db` — backup file and checkpoint JSON created correctly
- [x] `tools-registry: approve_hitl is absent` test explicitly verifies the removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)