### PR TITLE
fix(hitl): flip strict-mode default — complex tasks without context now require HITL

### DIFF
--- a/packages/core/src/__tests__/hitl-incomplete-context.test.ts
+++ b/packages/core/src/__tests__/hitl-incomplete-context.test.ts
@@ -44,6 +44,16 @@ test('incomplete context: complex without fields — strict=1 requires HITL, str
   assert.ok(loose.trigger.axes.includes('strict_mode_downgraded'))
 })
 
+test('incomplete context: default env (no GIJUN_HITL_STRICT_MODE) enforces HITL for complex without fields', () => {
+  // v0.1.2: strict is the default. GIJUN_HITL_STRICT_MODE=0 opts out.
+  const defaultDecision = evaluateHitlForTask(
+    { complexity: 'complex' },
+    { env: {} as NodeJS.ProcessEnv },  // no GIJUN_HITL_STRICT_MODE set
+  )
+  assert.equal(defaultDecision.hitlRequired, true, 'default should now require HITL (strict by default)')
+  assert.ok(defaultDecision.trigger.axes.includes('incomplete_context'))
+})
+
 test('incomplete context: trivial and standard are never escalated', () => {
   for (const c of ['trivial', 'standard'] as const) {
     const decision = evaluateHitlForTask(

--- a/packages/core/src/hitl/gate.ts
+++ b/packages/core/src/hitl/gate.ts
@@ -110,7 +110,8 @@ export type TaskHitlTriggerPayload = {
 }
 
 function strictModeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env['GIJUN_HITL_STRICT_MODE'] === '1'
+  // v0.1.2: strict is the default. Opt out with GIJUN_HITL_STRICT_MODE=0.
+  return env['GIJUN_HITL_STRICT_MODE'] !== '0'
 }
 
 /**
@@ -122,10 +123,9 @@ function strictModeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
  *
  * Fail-closed principle: missing context fields escalate severity rather than
  * weaken the gate. critical complexity always requires HITL regardless of fields.
- * complex complexity requires HITL when strict mode is enabled OR all context
- * fields are present; otherwise v0.1.1 default emits a warning and lets it pass
- * (GIJUN_HITL_STRICT_MODE env var gates the transition — v0.1.2 will flip the
- * default to strict).
+ * complex complexity requires HITL unless all context fields are absent AND
+ * GIJUN_HITL_STRICT_MODE=0 is explicitly set (opt-out). v0.1.2: strict is the
+ * default; set GIJUN_HITL_STRICT_MODE=0 to restore the lenient v0.1.1 behaviour.
  */
 export function evaluateTaskHitl(
   input: TaskHitlInput,
@@ -160,7 +160,7 @@ export function evaluateTaskHitl(
       hitlRequired = false
       axes.push('strict_mode_downgraded')
       console.warn(
-        '[agentguard] complex task created without toolName/actionType/resource; HITL downgraded to 0 (set GIJUN_HITL_STRICT_MODE=1 to enforce)',
+        '[agentguard] complex task created without toolName/actionType/resource; HITL downgraded to 0 (set GIJUN_HITL_STRICT_MODE=0 to suppress)',
       )
     }
   } else {


### PR DESCRIPTION
## Summary

- Closes M-1 from the security audit: `incomplete_context` was a warning-only case that let complex tasks proceed without HITL when `toolName`/`actionType`/`resource` were absent.
- **v0.1.2 change**: `GIJUN_HITL_STRICT_MODE` now defaults to strict (`!== '0'` instead of `=== '1'`). Opt out with `GIJUN_HITL_STRICT_MODE=0`.

## Test plan

- [x] `pnpm test` (core) → 104/104 pass, 0 fail
- [x] New test `incomplete context: default env enforces HITL` pins the v0.1.2 default
- [x] Existing tests for explicit `strict=1`/`strict=0` still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)