### PR TITLE
fix: health 응답 타입 정정 + README status 배지 동기화

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![node](https://img.shields.io/badge/node-%E2%89%A522-brightgreen)
 ![pnpm](https://img.shields.io/badge/pnpm-%E2%89%A59-orange)
-![status](https://img.shields.io/badge/status-v0.3.1-blue)
+![status](https://img.shields.io/badge/status-v0.2.0-blue)
 
 **Status: 개인용 1인 도구 — 프로덕션 의존성으로 사용 불가.** HITL 게이트는 1인 개발자를 위한 자기 승인(self-approval) 속도 제한 장치이지 다인 거버넌스가 아닙니다. 팀 모드·RBAC·다중 사용자 separation-of-duties가 필요하면 프로젝트를 포크하세요.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![node](https://img.shields.io/badge/node-%E2%89%A522-brightgreen)
 ![pnpm](https://img.shields.io/badge/pnpm-%E2%89%A59-orange)
-![status](https://img.shields.io/badge/status-v0.3.1-blue)
+![status](https://img.shields.io/badge/status-v0.2.0-blue)
 
 **Status: personal single-user tool — not a production dependency.** The HITL gate is a self-approval speed-bump for a solo developer, not multi-party governance. Fork the project if you need team mode, RBAC, or multi-user separation-of-duties.
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -31,7 +31,7 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export const api = {
-  health: () => apiFetch<{ status: string }>('/health'),
+  health: () => apiFetch<{ ok: boolean; version: string }>('/health'),
   tasks: (params?: { status?: string; limit?: number }) => {
     const q = new URLSearchParams()
     if (params?.status) q.set('status', params.status)


### PR DESCRIPTION
## Summary

- `packages/web/src/lib/api.ts`: `health()` 반환 타입 `{status:string}` → `{ok:boolean; version:string}` 수정
  - 서버 `app.ts`의 실제 응답 `{ok:true, version:VERSION}`과 불일치 해소
- `README.md`, `README.ko.md`: status 배지 `v0.3.1` → `v0.2.0`
  - 루트 `package.json` 버전(0.2.0)과 일치

## Test plan

- [ ] `tsc --noEmit` 통과 확인 (packages/web)
- [ ] `/health` 엔드포인트 응답이 `{ok:true, version:"0.2.0"}` 형식인지 확인
- [ ] README 배지가 v0.2.0으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)