### PR TITLE
docs: rename external surface to policyloop (gijun-ai → policyloop)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,10 +1,14 @@
 [English](./README.md) · [한국어](./README.ko.md)
 
-# gijun-ai
+# policyloop
 
 > **기준을 세우고, 검증하며, 학습한다.**
 >
+> 개인용 AI 에이전트 거버넌스 (기업 정책 도구 아님) — `policyloop`는 모든 결정 루프를 닫는다.
+>
 > 1인용 AI 에이전트 audit/검증 워크벤치 — 중요한 것을 바꾸는 모든 Claude/LLM 세션을 감사·검증·학습한다.
+>
+> _`gijun` (기준, the standard) — internal codename · 디렉토리 / npm 경로 / GitHub repo는 `gijun-ai` 그대로 유지._
 
 ![version](https://img.shields.io/github/package-json/v/aniboy2k-gif/gijun-AI?color=blue)
 ![license](https://img.shields.io/badge/license-MIT-green)
@@ -16,11 +20,11 @@
 
 ---
 
-## gijun-ai가 필요한 이유
+## policyloop가 필요한 이유
 
 Claude Max 또는 유사한 에이전트 티어를 사용하는 개인 개발자들은 진짜 중요한 일을 합니다 — 코드를 릴리스하고, 프로덕션을 건드리고, 정책 문서를 수정합니다. 그러나 에이전트의 추론·승인·비용 흔적은 세션이 끝나는 순간 모두 사라집니다. 분쟁 시 믿을 만한 감사 로그도 없고, 어설프게 검증된 아이디어의 실행을 막을 게이트도 없으며, `/clear` 이후에도 남는 메모리도 없습니다.
 
-**gijun-ai**는 사용자와 에이전트 사이에 위치하는 로컬 우선 audit/검증 레이어입니다:
+**policyloop**는 사용자와 에이전트 사이에 위치하는 로컬 우선 audit/검증 레이어입니다:
 
 - **Audit** — 모든 결정을 append-only SHA-256 해시 체인으로 기록하여 redaction 이후에도 무결성 유지
 - **Verify** — 중요한 작업은 실행 전에 4축 HITL(Human-In-The-Loop) 게이트를 통과해야 합니다
@@ -147,7 +151,7 @@ AGENTGUARD_TOKEN="$AGENTGUARD_TOKEN" \
 
 ### 2. Task + HITL Gate — 4축 트리거
 
-작업은 `complexity` 축(`trivial | standard | complex | critical`)을 가집니다. HITL 평가는 네 가지 차원을 결합합니다: **irreversibility**, **blast_radius**, **complexity**, **verify_fail**. 어느 한 축이라도 임계치를 넘으면 작업은 `hitl_wait` 상태로 전환됩니다. 운영자(= 당신 — gijun-ai는 1인용)가 직접 `POST /tasks/:id/hitl-approve`를 호출해야 비가역 실행이 진행됩니다. 이는 잊혀진 폭주 에이전트에 대한 **자기 승인 속도 제한** 장치이지 다인 거버넌스가 아닙니다. separation-of-duties가 필요하면 포크가 필수입니다.
+작업은 `complexity` 축(`trivial | standard | complex | critical`)을 가집니다. HITL 평가는 네 가지 차원을 결합합니다: **irreversibility**, **blast_radius**, **complexity**, **verify_fail**. 어느 한 축이라도 임계치를 넘으면 작업은 `hitl_wait` 상태로 전환됩니다. 운영자(= 당신 — policyloop는 1인용)가 직접 `POST /tasks/:id/hitl-approve`를 호출해야 비가역 실행이 진행됩니다. 이는 잊혀진 폭주 에이전트에 대한 **자기 승인 속도 제한** 장치이지 다인 거버넌스가 아닙니다. separation-of-duties가 필요하면 포크가 필수입니다.
 
 주요 파일: `packages/core/src/task/service.ts`, `packages/core/src/hitl/gate.ts`
 
@@ -408,7 +412,7 @@ OWASP의 Agentic Security Initiative top-10을 본 코드베이스에 매핑. **
 
 ### ASI03 — Training Data Poisoning
 
-**범위**: gijun-ai 범위 외. 우리는 모델을 호스팅하거나 파인튜닝하지 않음 — 업스트림 모델 위생은 제공자 책임. 다만 trace별로 모델/제공자를 기록하므로 세션 전반에 걸쳐 오염 패턴을 발견할 수 있음.
+**범위**: policyloop 범위 외. 우리는 모델을 호스팅하거나 파인튜닝하지 않음 — 업스트림 모델 위생은 제공자 책임. 다만 trace별로 모델/제공자를 기록하므로 세션 전반에 걸쳐 오염 패턴을 발견할 수 있음.
 **모듈**: `packages/core/src/tracer/service.ts`
 
 ### ASI04 — Model Denial of Service
@@ -521,7 +525,7 @@ DA-chain 합의 기능 집합 (P0 + P1 + P2). 점진적 감사 검증, 다중 �
 
 ### 범위 외 (포크가 필요함)
 
-gijun-ai는 1인용 도구입니다. 아래 항목은 **로드맵에 없음** — 필요하면 프로젝트를 포크하세요:
+policyloop는 1인용 도구입니다. 아래 항목은 **로드맵에 없음** — 필요하면 프로젝트를 포크하세요:
 
 - 리더 선출 기반 감사 복제 멀티 인스턴스 모드
 - 사용자별 토큰과 RBAC가 있는 팀 모드
@@ -530,7 +534,7 @@ gijun-ai는 1인용 도구입니다. 아래 항목은 **로드맵에 없음** �
 
 ### 로드맵에 없는 것
 
-클라우드 호스팅 SaaS, 조직 단위 과금, 모델 호스팅, 협업 편집. 이 중 하나라도 중요하게 들린다면 gijun-ai는 맞는 도구가 아닙니다 — 단일 키보드 앞의 단일 개발자를 위해 만들어졌습니다.
+클라우드 호스팅 SaaS, 조직 단위 과금, 모델 호스팅, 협업 편집. 이 중 하나라도 중요하게 들린다면 policyloop는 맞는 도구가 아닙니다 — 단일 키보드 앞의 단일 개발자를 위해 만들어졌습니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 [English](./README.md) · [한국어](./README.ko.md)
 
-# gijun-ai
+# policyloop
 
 > **Set the standard. Verify the work. Learn from the session.**
 >
+> Personal AI agent governance, not enterprise policy — `policyloop` closes every decision loop.
+>
 > A personal single-user audit/verification workbench — audit, verify, and learn from every Claude/LLM session that changes something that matters.
+>
+> _`gijun` (기준, "the standard") — internal codename · directory / npm path / GitHub repo retain the `gijun-ai` name._
 
 ![version](https://img.shields.io/github/package-json/v/aniboy2k-gif/gijun-AI?color=blue)
 ![license](https://img.shields.io/badge/license-MIT-green)
@@ -16,11 +20,11 @@
 
 ---
 
-## Why gijun-ai
+## Why policyloop
 
 Solo developers running Claude Max or similar agent tiers do serious work — ship code, touch production, edit policy documents — but the agent's reasoning, approvals, and cost footprint evaporate the moment the session ends. There's no audit trail you'd trust in a dispute, no gate to stop a half-verified idea from being executed, no memory that survives a `/clear`.
 
-**gijun-ai** is a local-first audit/verification layer that sits between you and your agent:
+**policyloop** is a local-first audit/verification layer that sits between you and your agent:
 
 - **Audit** every decision to an append-only SHA-256 hash chain that survives redaction
 - **Verify** critical actions through a 4-axis HITL (human-in-the-loop) gate before they run
@@ -162,7 +166,7 @@ The HITL surface has two distinct entry points; the README/CHANGELOG abbreviatio
 - `incomplete_context` — `complex` without context
 - `strict_mode_downgraded` — `complex` without context with `GIJUN_HITL_STRICT_MODE!=1` (warning, lets through; v0.1.2 will flip the default)
 
-The operator (you — gijun-ai is single-user) must explicitly call `POST /tasks/:id/hitl-approve` before a task can transition to `done`. This is a self-approval speed-bump against a forgetful runaway agent, not multi-party governance; fork the project if you need separation-of-duties.
+The operator (you — policyloop is single-user) must explicitly call `POST /tasks/:id/hitl-approve` before a task can transition to `done`. This is a self-approval speed-bump against a forgetful runaway agent, not multi-party governance; fork the project if you need separation-of-duties.
 
 Key files: `packages/core/src/task/service.ts`, `packages/core/src/hitl/gate.ts`
 
@@ -425,7 +429,7 @@ Each ASI claim below carries a verification label so readers know which claims a
 
 ### ASI03 — Training Data Poisoning
 
-**Scope**: out of scope for gijun-ai. We do not host or fine-tune models; upstream model hygiene is the provider's responsibility. We do, however, record the model/provider per trace so poisoning patterns can be spotted across sessions.
+**Scope**: out of scope for policyloop. We do not host or fine-tune models; upstream model hygiene is the provider's responsibility. We do, however, record the model/provider per trace so poisoning patterns can be spotted across sessions.
 **Modules**: `packages/core/src/tracer/service.ts`
 
 ### ASI04 — Model Denial of Service
@@ -558,7 +562,7 @@ The following items have explicit reopening triggers — they will move forward 
 
 ### Out of scope (fork required)
 
-gijun-ai is a single-user tool. The following are **not on the roadmap** — if you need them, fork the project:
+policyloop is a single-user tool. The following are **not on the roadmap** — if you need them, fork the project:
 
 - Multi-instance mode with leader-elected audit replication
 - Team mode with per-user tokens and RBAC
@@ -567,7 +571,7 @@ gijun-ai is a single-user tool. The following are **not on the roadmap** — if 
 
 ### Not on the roadmap
 
-Cloud-hosted SaaS, organization-level billing, model hosting, collaborative editing. If any of these sound important, gijun-ai is probably not the tool — it's built for a single developer at a single keyboard.
+Cloud-hosted SaaS, organization-level billing, model hosting, collaborative editing. If any of these sound important, policyloop is probably not the tool — it's built for a single developer at a single keyboard.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gijun-ai",
+  "name": "policyloop",
   "version": "0.2.0",
   "description": "Personal single-user AI agent audit/verification workbench — 기준을 세우고, 검증하며, 학습한다",
   "license": "MIT",

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -26,7 +26,7 @@ function readRepoVersion(): string {
   for (const p of candidates) {
     try {
       const pkg = JSON.parse(readFileSync(p, 'utf8')) as { name?: string; version?: string }
-      if (pkg.name === 'gijun-ai' && pkg.version) return pkg.version
+      if ((pkg.name === 'policyloop' || pkg.name === 'gijun-ai') && pkg.version) return pkg.version
     } catch {
       // try next candidate
     }


### PR DESCRIPTION
## Summary

CSR #523 comment #1798/#1800 DA Tier 2 결정의 코드 반영 — 외부 노출 명칭만 `policyloop`로 변경. 내부 패키지·디렉토리·환경변수·GitHub repo·DB 파일명은 모두 유지.

## 변경 범위

- `package.json` root `name`: `gijun-ai` → `policyloop`
- `README.md` / `README.ko.md` 자연어 외부 노출 문구 → `policyloop`
  - 제목, `Why ...` 섹션 헤더, `single-user` 문구, `out-of-scope` 표현
  - 상단에 부제 추가: _`gijun` (기준, the standard) — internal codename · directory / npm path / GitHub repo retain the `gijun-ai` name._

## 유지 (사용자 결정 '외부 명칭만 rename')

- 내부 패키지명: `@gijun-ai/core`, `@gijun-ai/server`, `@gijun-ai/web`, `@gijun-ai/mcp-server`
- 디렉토리명: `~/workspace/gijun-ai`
- GitHub repo: `aniboy2k-gif/gijun-AI`
- 환경변수: `AGENTGUARD_TOKEN`, `AGENTGUARD_PORT`, `AGENTGUARD_DB_PATH`
- DB 파일명: `gijun.db`
- PM2 process 이름: `gijun-ai-server`
- MCP config 예시 키 이름 (사용자가 자기 ID로 정함)

## Test plan

- [x] `pnpm build`: core·web·mcp-server·server 4 packages exit 0
- [ ] CI claim-check (README 자동 검증)
- [ ] CI build & test on Node 22 ubuntu / macos
- [ ] CI CodeQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)