### PR TITLE
feat(web): HITL approval button in TasksTab (v0.5.x #1)

### DIFF
--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -44,4 +44,9 @@ export const api = {
   costSummary: (period: string) => apiFetch<unknown>(`/traces/summary?period=${period}`),
   knowledgeDrafts: () => apiFetch<unknown[]>('/knowledge/drafts'),
   knowledge: () => apiFetch<unknown[]>('/knowledge'),
+  approveHitl: (id: number, body?: { approver?: string; note?: string }) =>
+    apiFetch<{ task: { id: number; status: string; hitl_approved_at: string } }>(
+      `/tasks/${id}/hitl-approve`,
+      { method: 'POST', body: JSON.stringify(body ?? {}) },
+    ),
 }

--- a/packages/web/src/tabs/TasksTab.tsx
+++ b/packages/web/src/tabs/TasksTab.tsx
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from '@/lib/api'
-import { RefreshCw } from 'lucide-react'
+import { Check, RefreshCw } from 'lucide-react'
 
 type Task = {
   id: number; title: string; status: string; complexity: string
@@ -16,6 +16,7 @@ const STATUS_COLORS: Record<string, string> = {
 }
 
 export function TasksTab() {
+  const qc = useQueryClient()
   const { data, isLoading, isError, refetch, isFetching } = useQuery({
     queryKey: ['tasks'],
     queryFn: () => api.tasks({ limit: 50 }) as Promise<Task[]>,
@@ -24,11 +25,21 @@ export function TasksTab() {
     refetchOnWindowFocus: true,
   })
 
+  const approveMutation = useMutation({
+    mutationFn: (id: number) => api.approveHitl(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tasks'] }),
+  })
+
   if (isLoading) return <Skeleton />
   if (isError) return <ErrorState onRetry={() => void refetch()} />
 
   const tasks = data ?? []
   const hitlPending = tasks.filter(t => t.status === 'hitl_wait')
+
+  const handleApprove = (task: Task) => {
+    if (!confirm(`HITL 승인: #${task.id} "${task.title}"\n\n승인 후 작업이 진행됩니다. 계속하시겠습니까?`)) return
+    approveMutation.mutate(task.id)
+  }
 
   return (
     <div className="space-y-4">
@@ -47,24 +58,42 @@ export function TasksTab() {
         </button>
       </div>
 
+      {approveMutation.isError && (
+        <p className="text-xs text-red-600 px-1">승인 실패: {(approveMutation.error as Error).message}</p>
+      )}
+
       {tasks.length === 0 ? (
         <p className="text-sm text-muted-foreground py-8 text-center">작업 없음</p>
       ) : (
         <div className="space-y-2">
-          {tasks.map(task => (
-            <div key={task.id}
-              className="flex items-center justify-between p-3 border border-border rounded-lg hover:bg-accent/50">
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium truncate">{task.title}</p>
-                <p className="text-xs text-muted-foreground">
-                  #{task.id} · {task.complexity} · {new Date(task.created_at).toLocaleDateString('ko')}
-                </p>
+          {tasks.map(task => {
+            const isApproving = approveMutation.isPending && approveMutation.variables === task.id
+            return (
+              <div key={task.id}
+                className="flex items-center justify-between p-3 border border-border rounded-lg hover:bg-accent/50">
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium truncate">{task.title}</p>
+                  <p className="text-xs text-muted-foreground">
+                    #{task.id} · {task.complexity} · {new Date(task.created_at).toLocaleDateString('ko')}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0 ml-3">
+                  {task.status === 'hitl_wait' && (
+                    <button type="button"
+                      onClick={() => handleApprove(task)}
+                      disabled={isApproving}
+                      className="flex items-center gap-1 h-6 px-2 text-xs font-medium border border-orange-300 text-orange-700 hover:bg-orange-50 rounded disabled:opacity-40">
+                      <Check size={12} className={isApproving ? 'animate-pulse' : ''} />
+                      {isApproving ? '승인 중' : '승인'}
+                    </button>
+                  )}
+                  <span className={`px-2 py-0.5 text-xs rounded-full ${STATUS_COLORS[task.status] ?? 'bg-gray-100'}`}>
+                    {task.status}
+                  </span>
+                </div>
               </div>
-              <span className={`ml-3 px-2 py-0.5 text-xs rounded-full shrink-0 ${STATUS_COLORS[task.status] ?? 'bg-gray-100'}`}>
-                {task.status}
-              </span>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

CSR #750 — v0.5.x 첫 기능. Web dashboard에 HITL approval 버튼 추가.

기존: HITL-wait task는 CLI(`scripts/approve-hitl.mjs`) 또는 curl로만 승인 가능 (Web read-only).
변경: TasksTab에서 `status='hitl_wait'` 행에 인라인 "승인" 버튼 표시.

## Changes

- `packages/web/src/lib/api.ts`: `api.approveHitl(id, body?)` 추가 (기존 `POST /tasks/:id/hitl-approve` endpoint wrap)
- `packages/web/src/tabs/TasksTab.tsx`:
  - `useMutation` + `useQueryClient` 도입
  - `confirm()` dialog로 실수 방지
  - per-task pending spinner (`variables === task.id`)
  - 성공 시 `invalidateQueries(['tasks'])` → 5초 polling으로 새 status 반영
  - 실패 시 inline error 표시

## Test plan

- [x] `pnpm --filter @gijun-ai/web build` exit 0 (254KB / 78KB gzip)
- [x] TypeScript 컴파일 PASS
- [ ] CI build & test on Node 22 (ubuntu·macos)
- [ ] CI README claim-check
- [ ] CI CodeQL

## E2E (수동 검증, 머지 후 권장)

1. HITL-required task 생성 (complexity=critical 또는 irreversible action)
2. Web /tasks → hitl_wait 행에 "승인" 버튼 표시 확인
3. 버튼 클릭 → confirm dialog → OK → status가 done으로 5s 내 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)