### PR TITLE
chore(release): v0.5.0 — CHANGELOG + version bump + README sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,51 @@
 # Changelog
 
-All notable changes to `gijun-ai` are documented here.
+All notable changes to `policyloop` (formerly `gijun-ai`) are documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), semver.
+
+## [0.5.0] — 2026-05-21
+
+### Context
+
+First v0.5.x release. External-surface rename to `policyloop` (CSR #1798/#1800 DA Tier 2)
+and the first write action in the web dashboard: a HITL approval button. Internal
+package names (`@gijun-ai/core`, `@gijun-ai/server`, `@gijun-ai/web`,
+`@gijun-ai/mcp-server`), directory, GitHub repo, and env vars (`AGENTGUARD_*`) are
+unchanged — this is an external-name-only migration per user decision.
+
+### Added
+
+- **HITL approval button (web)** — `TasksTab` renders an inline `승인` button on
+  `status='hitl_wait'` rows. Confirm dialog prevents accidents; per-task pending
+  spinner; tanstack-query `invalidateQueries(['tasks'])` on success so the 5s poll
+  picks up the new state. Inline error on failure. (#34)
+- **`api.approveHitl(id, body?)`** — Web `lib/api.ts` wrapper around the existing
+  `POST /tasks/:id/hitl-approve` endpoint (token-protected). (#34)
+
+### Changed
+
+- **External name → `policyloop`** — `package.json` root `name`, README titles,
+  `Why` section heading, single-user copy, and `out-of-scope` wording all renamed.
+  README sub-line preserves the internal codename: _`gijun` (기준, the standard)
+  — internal codename · directory / npm path / GitHub repo retain the `gijun-ai`
+  name._ (#33)
+- **`readRepoVersion()`** (`packages/server/src/app.ts`) — accepts both
+  `policyloop` and `gijun-ai` as the repo identifier so legacy clones and forks
+  still produce a correct `/health.version` value. (#33)
+- **Known-limitations entry** — "No UI" → "Minimal UI: read-only dashboard with
+  HITL approval button."
+
+### Operational (no code change in this repo)
+
+- gijun-ai workspace moved from external volume to `~/workspace/gijun-ai` (bulletin-board CSR #747).
+- `pm2 startup launchd` registered (`com.PM2`) so the three PM2 processes
+  resurrect on reboot (CSR #747).
+- bulletin-board moved to `~/workspace/bulletin-board`; gijun-outbox-worker
+  inherits the new path (CSR #748).
+- External-volume originals deleted (~831MB reclaimed) (CSR #751).
+
+---
 
 ## [0.4.0] — 2026-04-29
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -14,7 +14,7 @@
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![node](https://img.shields.io/badge/node-%E2%89%A522-brightgreen)
 ![pnpm](https://img.shields.io/badge/pnpm-%E2%89%A59-orange)
-![status](https://img.shields.io/badge/status-v0.2.0-blue)
+![status](https://img.shields.io/badge/status-v0.5.0-blue)
 
 **Status: 개인용 1인 도구 — 프로덕션 의존성으로 사용 불가.** HITL 게이트는 1인 개발자를 위한 자기 승인(self-approval) 속도 제한 장치이지 다인 거버넌스가 아닙니다. 팀 모드·RBAC·다중 사용자 separation-of-duties가 필요하면 프로젝트를 포크하세요.
 
@@ -461,7 +461,7 @@ v0.1은 **단일 로컬 인스턴스를 운영하는 1인 개발자**를 위한 
 - **인증 공급자 통합 없음** — 서버당 `AGENTGUARD_TOKEN` 하나, 수동 회전.
 - **부분 MCP 커버리지** — 22개 도구는 공통 경로 에이전트 동작을 다룸; `POST /tasks/external`, `POST /knowledge/:id/restore`, playbook CRUD(GET 제외), incident 패턴 승격, 원시 policy CRUD, `POST /traces` / `POST /verifications`는 REST 전용.
 - **Windows 미검증** — 모든 개발은 macOS Darwin 25.x에서; Linux는 작동 예상.
-- **UI 없음** — 모든 것은 REST + MCP. `packages/web` 슬롯이 있으나 비어 있음 (P4 대시보드 진행 중).
+- **최소 UI** — 읽기 전용 웹 대시보드(Tasks · Audit · Cost · Knowledge)에 단일 쓰기 액션: `status='hitl_wait'` 작업의 HITL 승인 버튼(v0.5.0부터). task/knowledge 전체 쓰기 UI는 아직 미제공 — REST/MCP 사용.
 
 이는 간과가 아닌 정직한 스코프 판단입니다. 하나씩 이 목록에서 빠져나갈 것입니다.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![node](https://img.shields.io/badge/node-%E2%89%A522-brightgreen)
 ![pnpm](https://img.shields.io/badge/pnpm-%E2%89%A59-orange)
-![status](https://img.shields.io/badge/status-v0.2.0-blue)
+![status](https://img.shields.io/badge/status-v0.5.0-blue)
 
 **Status: personal single-user tool — not a production dependency.** The HITL gate is a self-approval speed-bump for a solo developer, not multi-party governance. Fork the project if you need team mode, RBAC, or multi-user separation-of-duties.
 
@@ -498,7 +498,7 @@ v0.2 is an alpha for **solo developers running a single local instance**. Things
 - **No auth provider integration** — one `AGENTGUARD_TOKEN` per server, rotated by hand.
 - **Partial MCP coverage** — 22 tools cover the common-path agent actions; `POST /tasks/external`, `POST /knowledge/:id/restore`, playbook CRUD beyond GET, incident pattern promotion, raw policy CRUD, `POST /traces`, and `POST /verifications` are REST-only.
 - **Windows untested** — all dev on macOS Darwin 25.x; Linux expected to work.
-- **No UI** — everything is REST + MCP. A `packages/web` slot exists but is empty (P4 dashboard is the next roadmap item).
+- **Minimal UI** — read-only web dashboard (Tasks · Audit · Cost · Knowledge) with a single write action: HITL approval button on `status='hitl_wait'` tasks (since v0.5.0). Full write UI for tasks/knowledge is not yet provided; use REST or MCP for those.
 
 These are honest scope calls, not oversights. They will move out of this list one by one.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "policyloop",
-  "version": "0.2.0",
+  "version": "0.5.0",
   "description": "Personal single-user AI agent audit/verification workbench — 기준을 세우고, 검증하며, 학습한다",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Summary

CSR #752. Bundles the user-facing surface for the v0.5.0 milestone after #33 (policyloop rename) and #34 (HITL approval button) merged into main.

## Changes

- `package.json`: `version` 0.2.0 → 0.5.0
- `CHANGELOG.md`: new `[0.5.0] — 2026-05-21` entry covering #33, #34, and the operational moves (CSRs #747/#748/#751). Header line references "policyloop (formerly gijun-ai)".
- `README.md` / `README.ko.md`:
  - status badge 0.2.0 → 0.5.0
  - "No UI" known-limitations entry → "Minimal UI" (HITL approve button is the first write action)

## Verification

- [x] `pnpm build` — 4 packages exit 0
- [x] `pnpm -r test` — server 15/15, core/mcp-server "Done" (no failures)
- [ ] CI build & test (ubuntu/macos)
- [ ] CI README claim-check
- [ ] CI CodeQL

## After merge

- `git tag v0.5.0` + `git push origin v0.5.0` (release tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)