### PR TITLE
chore(ops): commit ecosystem.config.js + gitignore npm artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@ dist-test
 .DS_Store
 prompt_plan.md
 
+# pnpm workspace — package-lock.json is npm artifact, not used here
+package-lock.json
+
 # backup script output
 backups/

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,50 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function loadEnvLocal(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`ecosystem: required env file not found: ${filePath}`);
+  }
+  const out = {};
+  const raw = fs.readFileSync(filePath, 'utf8');
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let val = trimmed.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+const env = loadEnvLocal(path.join(__dirname, '.env.local'));
+if (!env.AGENTGUARD_TOKEN) {
+  throw new Error('ecosystem: AGENTGUARD_TOKEN missing in .env.local');
+}
+
+module.exports = {
+  apps: [{
+    name: 'gijun-ai-server',
+    script: './packages/server/dist/server.js',
+    cwd: __dirname,
+    instances: 1,
+    exec_mode: 'fork',
+    autorestart: true,
+    watch: false,
+    max_memory_restart: '256M',
+    restart_delay: 3000,
+    max_restarts: 50,
+    min_uptime: '60s',
+    env: {
+      NODE_ENV: 'production',
+      AGENTGUARD_TOKEN: env.AGENTGUARD_TOKEN,
+      AGENTGUARD_DB_PATH: path.join(__dirname, 'gijun.db'),
+      AGENTGUARD_PORT: '3456',
+    },
+  }],
+};


### PR DESCRIPTION
## Summary

Two minor housekeeping items uncovered while moving the workspace to `~/workspace/gijun-ai` (CSR #747):

1. **`ecosystem.config.js` is now tracked.** It was created during the move to run `gijun-ai-server` under PM2. It reads `AGENTGUARD_TOKEN` from `.env.local` at startup (gitignored), and uses `cwd: __dirname` so it's portable across clone locations. No secrets in git.
2. **`package-lock.json` is now gitignored.** The repo is a pnpm workspace (`pnpm-lock.yaml` is the source of truth); the stray `package-lock.json` was an artifact of an accidental `npm install`. Removed from working tree and ignored going forward.

No application code changed. CI should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)