### PR TITLE
fix(hitl): correct hitl_trigger axes shape + UI gate condition

### DIFF
--- a/packages/server/src/__tests__/rest-hitl-flow.e2e.test.ts
+++ b/packages/server/src/__tests__/rest-hitl-flow.e2e.test.ts
@@ -129,3 +129,89 @@ test('E2E auth: request without X-AgentGuard-Token returns 401', async () => {
   })
   assert.equal(res.status, 401, 'fail-closed auth must reject missing token')
 })
+
+test('E2E HITL reject: critical task PATCH cancelled does not require approval', async () => {
+  // Reject path: a task that requires HITL approval can be cancelled without
+  // prior approval. This is the backend contract behind the web "거부" button.
+  // Note: createTask sets status='pending'; hitl_required=1 is the signal
+  // the UI should match on (not status==='hitl_wait', which is only reached
+  // via explicit PATCH).
+  const createRes = await fetch(`${baseUrl}/tasks`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({
+      title: 'e2e reject task',
+      complexity: 'critical',
+      toolName: 'bash',
+      actionType: 'execute',
+      resource: 'prod-db',
+    }),
+  })
+  assert.equal(createRes.status, 201, 'task creation should succeed (201 Created)')
+  const { id } = (await createRes.json()) as { id: number }
+
+  // Initial state: status='pending', hitl_required=1, hitl_approved_at=null.
+  // This is what the UI sees as the "needs HITL" condition.
+  const getBefore = await fetch(`${baseUrl}/tasks/${id}`, { headers: authHeaders() })
+  const before = (await getBefore.json()) as {
+    status: string; hitl_required: number; hitl_approved_at: string | null
+  }
+  assert.equal(before.status, 'pending', 'critical task starts in status=pending')
+  assert.equal(before.hitl_required, 1, 'critical task must have hitl_required=1')
+  assert.equal(before.hitl_approved_at, null, 'critical task starts unapproved')
+
+  // PATCH to cancelled — should succeed without hitl-approve
+  const cancelRes = await fetch(`${baseUrl}/tasks/${id}/status`, {
+    method: 'PATCH',
+    headers: authHeaders(),
+    body: JSON.stringify({ status: 'cancelled' }),
+  })
+  assert.equal(
+    cancelRes.status,
+    200,
+    'cancelled transition should succeed without prior approval',
+  )
+
+  // Verify the state actually changed
+  const getAfter = await fetch(`${baseUrl}/tasks/${id}`, { headers: authHeaders() })
+  const after = (await getAfter.json()) as { status: string; hitl_approved_at: string | null }
+  assert.equal(after.status, 'cancelled', 'task status should be cancelled')
+  assert.equal(after.hitl_approved_at, null, 'cancelled task should not have hitl_approved_at')
+})
+
+test('E2E HITL trigger payload: hitl_trigger field is JSON with axes string[]', async () => {
+  // The web UI parses task.hitl_trigger to display the reason in Korean.
+  // This locks the API contract: hitl_trigger is a JSON string containing
+  // { axes: string[] } — each entry is the axis code itself (e.g.
+  // 'critical_complexity'), NOT an object with a `reason` field. This is the
+  // shape produced by evaluateTaskHitl() in packages/core/src/hitl/gate.ts.
+  const createRes = await fetch(`${baseUrl}/tasks`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({
+      title: 'e2e trigger payload',
+      complexity: 'critical',
+      toolName: 'bash',
+      actionType: 'execute',
+      resource: 'prod-db',
+    }),
+  })
+  const { id } = (await createRes.json()) as { id: number }
+
+  const getRes = await fetch(`${baseUrl}/tasks/${id}`, { headers: authHeaders() })
+  const task = (await getRes.json()) as { hitl_trigger: string | null }
+  assert.ok(task.hitl_trigger, 'critical task must record a hitl_trigger payload')
+
+  const parsed = JSON.parse(task.hitl_trigger as string) as { axes?: string[] }
+  assert.ok(Array.isArray(parsed.axes), 'hitl_trigger must contain an axes array')
+  assert.ok(parsed.axes.length > 0, 'critical task must have at least one axis')
+  assert.ok(
+    parsed.axes.includes('critical_complexity'),
+    `expected 'critical_complexity' in axes, got ${JSON.stringify(parsed.axes)}`,
+  )
+  // Lock the string-array shape: each entry must be a plain string code,
+  // not an object. This is what TasksTab.formatTrigger() relies on.
+  for (const axis of parsed.axes) {
+    assert.equal(typeof axis, 'string', `axes entry must be string, got ${typeof axis}`)
+  }
+})

--- a/packages/web/src/tabs/TasksTab.tsx
+++ b/packages/web/src/tabs/TasksTab.tsx
@@ -31,11 +31,15 @@ const TRIGGER_LABELS: Record<string, string> = {
 function formatTrigger(trigger: string | null): string | null {
   if (!trigger) return null
   try {
-    const parsed = JSON.parse(trigger) as { axes?: Array<{ reason?: string }>; reason?: string }
+    // hitl_trigger is produced by evaluateTaskHitl() in
+    // packages/core/src/hitl/gate.ts. axes is a string[] of axis codes
+    // (e.g. 'critical_complexity'), not an object array.
+    const parsed = JSON.parse(trigger) as { axes?: string[]; reason?: string }
     if (parsed.axes?.length) {
-      const reasons = parsed.axes.map(a => TRIGGER_LABELS[a.reason ?? ''] ?? a.reason).filter(Boolean)
-      return reasons.length ? reasons.join(', ') : null
+      const labels = parsed.axes.map(a => TRIGGER_LABELS[a] ?? a).filter(Boolean)
+      return labels.length ? labels.join(', ') : null
     }
+    // Step-level fallback: evaluateStepHitl returns { reason: ... }.
     if (parsed.reason) return TRIGGER_LABELS[parsed.reason] ?? parsed.reason
     return null
   } catch {
@@ -67,7 +71,15 @@ export function TasksTab() {
   if (isError) return <ErrorState onRetry={() => void refetch()} />
 
   const tasks = data ?? []
-  const hitlPending = tasks.filter(t => t.status === 'hitl_wait')
+  // A task "needs HITL" when hitl_required=1, not yet approved, and not in a
+  // terminal state. createTask sets status='pending' even for critical tasks,
+  // so matching only on status==='hitl_wait' would never show the button.
+  const needsHitl = (t: Task): boolean =>
+    t.hitl_required === 1
+    && t.hitl_approved_at === null
+    && t.status !== 'done'
+    && t.status !== 'cancelled'
+  const hitlPending = tasks.filter(needsHitl)
 
   const handleApprove = (task: Task) => {
     if (!confirm(`HITL 승인: #${task.id} "${task.title}"\n\n승인 후 작업이 진행됩니다. 계속하시겠습니까?`)) return
@@ -111,7 +123,8 @@ export function TasksTab() {
           {tasks.map(task => {
             const isApproving = approveMutation.isPending && approveMutation.variables === task.id
             const isRejecting = rejectMutation.isPending && rejectMutation.variables === task.id
-            const triggerText = task.status === 'hitl_wait' ? formatTrigger(task.hitl_trigger) : null
+            const showHitl = needsHitl(task)
+            const triggerText = showHitl ? formatTrigger(task.hitl_trigger) : null
             return (
               <div key={task.id}
                 className="flex items-center justify-between p-3 border border-border rounded-lg hover:bg-accent/50">
@@ -125,7 +138,7 @@ export function TasksTab() {
                   </p>
                 </div>
                 <div className="flex items-center gap-2 shrink-0 ml-3">
-                  {task.status === 'hitl_wait' && (
+                  {showHitl && (
                     <>
                       <button type="button"
                         onClick={() => handleApprove(task)}


### PR DESCRIPTION
## Summary

Two bugs uncovered by new backend e2e tests (added in this PR):

### (1) `hitl_trigger.axes` shape — `string[]`, not `Array<{reason}>`

`evaluateTaskHitl()` in `packages/core/src/hitl/gate.ts` produces `axes` as a plain string array of axis codes (e.g. `['critical_complexity']`). #36 wrongly parsed `axes` as `Array<{reason: string}>`, so the trigger reason in the UI rendered as nothing. Fixed `formatTrigger()` to read `axes` directly.

### (2) UI gate condition — `needsHitl` based on `hitl_required`, not `status`

`createTask` sets `status='pending'` for critical tasks too. The `hitl_required` flag (and absence of `hitl_approved_at`) is the real signal that a task is waiting for HITL. #34/#36 gated the buttons on `status === 'hitl_wait'`, which is only reached via explicit PATCH and was effectively dead UI.

Introduces `needsHitl(task: Task): boolean` predicate; reused for the badge count, the per-row buttons, and the trigger reason label.

## New backend e2e tests (regression locks)

- `E2E HITL reject`: critical task `PATCH /tasks/:id/status { status:'cancelled' }` succeeds **without** prior `hitl-approve`. Documents the contract behind the web 거부 button.
- `E2E HITL trigger payload`: `hitl_trigger` is JSON `{axes: string[]}` with `'critical_complexity'` present for critical tasks, every entry is a plain string.

## Verification

- [x] `pnpm --filter @gijun-ai/server test` — **17/17** (15 existing + 2 new)
- [x] `pnpm --filter @gijun-ai/web build` exit 0 (256KB / 78.78KB gzip)
- [ ] CI build & test (ubuntu/macos)
- [ ] CI README claim-check
- [ ] CI CodeQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)