### PR TITLE
chore(docs): complete policyloop rename in user-facing docs & templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,11 +1,11 @@
 name: Bug report
-description: Report a defect in gijun-ai
+description: Report a defect in policyloop
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        **Before you file**: gijun-ai is a personal single-user tool. If your bug report
+        **Before you file**: policyloop is a personal single-user tool. If your bug report
         describes a team/multi-user scenario, please note — those paths are out of scope
         and the "fix" is likely "fork required". See `CONTRIBUTING.md`.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Before you file**: gijun-ai deliberately stays single-user. Features that require
+        **Before you file**: policyloop deliberately stays single-user. Features that require
         multi-user auth, RBAC, SaaS hosting, or team collaboration are **out of scope** —
         fork instead. See `CONTRIBUTING.md` §"What is out of scope".
 
@@ -21,7 +21,7 @@ body:
     id: proposal
     attributes:
       label: Proposed behavior
-      description: How should gijun-ai behave once this feature exists? Be concrete.
+      description: How should policyloop behave once this feature exists? Be concrete.
     validations:
       required: true
 
@@ -44,12 +44,12 @@ body:
     id: alternatives
     attributes:
       label: Alternatives considered
-      description: Have you looked at Langfuse, Arize Phoenix, OpenLLMetry, or similar? Why does gijun-ai need to solve this directly rather than suggesting you use one of those?
+      description: Have you looked at Langfuse, Arize Phoenix, OpenLLMetry, or similar? Why does policyloop need to solve this directly rather than suggesting you use one of those?
 
   - type: textarea
     id: scope-check
     attributes:
       label: Scope sanity check
-      description: Is this compatible with gijun-ai's **single-user** scope? If it requires multi-user semantics, please describe the fork path instead.
+      description: Is this compatible with policyloop's **single-user** scope? If it requires multi-user semantics, please describe the fork path instead.
     validations:
       required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,4 +41,4 @@ If this PR changes `schema_migrations` order or adds a new migration:
 
 ## Single-user scope note
 
-gijun-ai is a **personal single-user tool**. External PRs are welcome but not guaranteed a response. For team mode, RBAC, or multi-user separation-of-duties, fork the project — those features are out of scope for this repo.
+policyloop is a **personal single-user tool**. External PRs are welcome but not guaranteed a response. For team mode, RBAC, or multi-user separation-of-duties, fork the project — those features are out of scope for this repo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to gijun-ai
+# Contributing to policyloop
 
 > **Status: personal single-user tool.** Issues and PRs are welcome, but this is an individual maintainer's project — responses are not guaranteed. For team mode / RBAC / multi-user needs, **fork** the project.
 
@@ -6,7 +6,7 @@
 
 - Read `README.md` top-of-page **"Status"** line — this tool is a solo audit workbench, not a framework for team adoption. Feature requests that require multi-user semantics will usually be declined with a "fork required" reply.
 - Check `docs/adoption-scenarios.md` — if your use case is in a `✗` row (team adoption, production dependency, compliance), a PR here is unlikely to land. Fork instead.
-- Check `docs/public-status-dod.md` — gijun-ai targets **L2 reference-only public**. PRs that would push the project into L3 territory (community-wide SLA, response guarantees) require a separate conversation first.
+- Check `docs/public-status-dod.md` — policyloop targets **L2 reference-only public**. PRs that would push the project into L3 territory (community-wide SLA, response guarantees) require a separate conversation first.
 
 ## Local development
 
@@ -22,7 +22,7 @@ Requirements: Node.js ≥ 22 (for native `node:sqlite`), pnpm ≥ 9.
 
 ## Pull request workflow
 
-1. **Scope the PR to a single framework axis.** gijun-ai's concerns split into five axes — Branding (A) / Reliability (B) / Authority (C) / Operations (D) / Legal (E). See `docs/project-framework.md`. A good PR touches one axis; PRs that touch multiple axes should be split.
+1. **Scope the PR to a single framework axis.** policyloop's concerns split into five axes — Branding (A) / Reliability (B) / Authority (C) / Operations (D) / Legal (E). See `docs/project-framework.md`. A good PR touches one axis; PRs that touch multiple axes should be split.
 2. **Match the commit style.** Conventional Commits (`fix:`, `feat:`, `docs:`, `refactor:`, `chore:`, `ci:`, `test:`). See `git log` for examples.
 3. **Update the README claim gate.**
    - If the PR adds or modifies an `ASI` mapping claim or an `Architecture contract`, add a matching entry to `.github/claim-map.yml` so the `claim-check` CI job validates it.
@@ -32,7 +32,7 @@ Requirements: Node.js ≥ 22 (for native `node:sqlite`), pnpm ≥ 9.
 
 ## What is out of scope
 
-gijun-ai deliberately does not accept contributions for:
+policyloop deliberately does not accept contributions for:
 
 - Multi-user authentication / RBAC / per-user tokens (would change C-1a scope — fork required)
 - SaaS / cloud hosting integration

--- a/docs/adoption-scenarios.md
+++ b/docs/adoption-scenarios.md
@@ -1,7 +1,7 @@
-# Adoption Scenarios — Is gijun-ai right for you?
+# Adoption Scenarios — Is policyloop right for you?
 
-> This document answers "should I use gijun-ai?" by scenario, not by feature.
-> The short version: gijun-ai is useful if you want to **learn** how a local
+> This document answers "should I use policyloop?" by scenario, not by feature.
+> The short version: policyloop is useful if you want to **learn** how a local
 > audit / HITL / policy layer is built, or if you want to **reference** the
 > architecture when building your own. It is **not** useful as a production
 > dependency for a team, because it is a deliberately single-user tool.
@@ -18,7 +18,7 @@
 | **Solo developer's personal workflow** — a single developer wanting to audit their own Claude Code sessions | ✓ (cautious) | This is the design target. Expect friction: manual token generation, CLI-only, no UI. If that's fine, `pnpm init && pnpm build` and you're running. |
 | **Team adoption** — multiple developers sharing a server instance | ✗ | **Not supported.** Single shared token = no per-user accountability. HITL approval cannot validate who actually approved. This is not an oversight; it is the C-1a scope decision. Fork for RBAC. |
 | **Production dependency** — staging / prod reliance on the audit chain for compliance evidence | ✗ | No CI / no SLA on security patches / no multi-instance replication / no external auditor verification procedure. See `docs/public-status-dod.md` — L4 is out of scope. |
-| **Regulatory compliance substrate** (SOC2 / ISO27001 / HIPAA) | ✗ | The audit chain is technically sound for a single-instance local record, but compliance requires far more (access controls, retention policy, disaster recovery, documented operational runbooks, auditor attestation). gijun-ai provides **none** of this ceremony. Use a vendor that does (Langfuse, Arize, etc.) or fork and build it. |
+| **Regulatory compliance substrate** (SOC2 / ISO27001 / HIPAA) | ✗ | The audit chain is technically sound for a single-instance local record, but compliance requires far more (access controls, retention policy, disaster recovery, documented operational runbooks, auditor attestation). policyloop provides **none** of this ceremony. Use a vendor that does (Langfuse, Arize, etc.) or fork and build it. |
 
 ---
 
@@ -30,13 +30,13 @@ If your situation maps to any of the `✗` rows above, consider these alternativ
 - **Production audit trail with compliance story** — build on top of your existing SIEM or use a vendor with certifications
 - **Agent policy enforcement for a team** — your IAM provider + a policy decision point (OPA, Cerbos) you already operate
 
-gijun-ai was built because none of those were the right fit for a single developer who wanted **local-first, no-cloud, no-vendor-lock, single-file SQLite** observability over their own AI agent use. If that is your constraint, gijun-ai is the answer. If not, there are better options.
+policyloop was built because none of those were the right fit for a single developer who wanted **local-first, no-cloud, no-vendor-lock, single-file SQLite** observability over their own AI agent use. If that is your constraint, policyloop is the answer. If not, there are better options.
 
 ---
 
 ## Expected friction (be honest before installing)
 
-Installing gijun-ai requires roughly this sequence:
+Installing policyloop requires roughly this sequence:
 
 1. Clone, `pnpm install`, `pnpm build`
 2. `openssl rand -hex 32` for a token; `export AGENTGUARD_TOKEN=…`
@@ -47,7 +47,7 @@ Installing gijun-ai requires roughly this sequence:
 
 Total: **~5 minutes**. The demo value of step 4 is: an API response saying `{"id": 1}`. There is no UI. There is no dashboard showing your audit events as a timeline — you can `GET /audit?n=20` but interpretation is manual.
 
-If you want one-command installation and a pretty dashboard, gijun-ai is not there yet (UI is on the `packages/web` roadmap but is not shipped in v0.1).
+If you want one-command installation and a pretty dashboard, policyloop is not there yet (UI is on the `packages/web` roadmap but is not shipped in v0.1).
 
 ---
 

--- a/docs/legal.md
+++ b/docs/legal.md
@@ -1,14 +1,14 @@
 # Legal & External-Dependency Risk (Axis E)
 
 > This document covers the legal, licensing, and external-dependency concerns
-> that define gijun-ai's **Axis E** (see `docs/project-framework.md`).
+> that define policyloop's **Axis E** (see `docs/project-framework.md`).
 >
-> None of this is legal advice. gijun-ai is a personal open-source project;
+> None of this is legal advice. policyloop is a personal open-source project;
 > consult your own counsel for your use case.
 
 ## License
 
-gijun-ai is **MIT licensed**. The full text is in the repository root `LICENSE` file. SPDX identifier: `MIT`.
+policyloop is **MIT licensed**. The full text is in the repository root `LICENSE` file. SPDX identifier: `MIT`.
 
 What this means in practice:
 
@@ -29,31 +29,31 @@ If you maintain a fork, you take on full responsibility for security patching, l
 
 ## PII / data-subject rights
 
-gijun-ai stores Claude/LLM session prompts and responses locally in a SQLite file. If your use case processes **personal data** (as defined by GDPR, CCPA, PIPA, etc.):
+policyloop stores Claude/LLM session prompts and responses locally in a SQLite file. If your use case processes **personal data** (as defined by GDPR, CCPA, PIPA, etc.):
 
 - The `payload` column can contain PII (user prompts, names, identifiers).
 - The `redactPayload()` function in `packages/core/src/audit/service.ts` blanks `payload` while preserving `original_hash` — audit chain integrity survives redaction.
 - For a right-to-erasure request, call `redactPayload(auditEventId, reason)` for each affected event. The event remains in the chain but carries only the hash.
-- This is a **technical redaction primitive**. Compliance with GDPR/CCPA/PIPA requires more — documented retention policy, DSAR response procedure, breach notification runbook, Data Processing Agreements with downstream consumers, etc. gijun-ai provides none of this out of the box.
+- This is a **technical redaction primitive**. Compliance with GDPR/CCPA/PIPA requires more — documented retention policy, DSAR response procedure, breach notification runbook, Data Processing Agreements with downstream consumers, etc. policyloop provides none of this out of the box.
 
-**If your use case is regulated**: either build the compliance layer on top of gijun-ai yourself, or use a vendor that has already done that work (Langfuse Enterprise, Arize, etc.).
+**If your use case is regulated**: either build the compliance layer on top of policyloop yourself, or use a vendor that has already done that work (Langfuse Enterprise, Arize, etc.).
 
 ## External dependency risk
 
-gijun-ai depends on external specifications and services that can change out from under us:
+policyloop depends on external specifications and services that can change out from under us:
 
 ### MCP specification
 - `@modelcontextprotocol/sdk` is pinned in `packages/mcp-server/package.json`. Pin carefully; upstream spec changes have previously broken client compatibility.
 - If a major MCP spec change ships, expect a forking fork (no pun): the MCP server may not be forward-compatible. Check `CHANGELOG.md` for tested MCP SDK versions.
 
 ### Claude Code / model-provider ToS
-- gijun-ai is agnostic to the model provider — it just records what you give it.
-- Claude Code's terms of service and Anthropic's model use policies evolve. If Anthropic's policy changes in a way that restricts agent telemetry logging, gijun-ai may need to be reconfigured (e.g., by default-redacting certain payload fields).
+- policyloop is agnostic to the model provider — it just records what you give it.
+- Claude Code's terms of service and Anthropic's model use policies evolve. If Anthropic's policy changes in a way that restricts agent telemetry logging, policyloop may need to be reconfigured (e.g., by default-redacting certain payload fields).
 - There is no automated monitor for provider ToS changes. Check upstream periodically.
 
 ### Node.js experimental APIs
-- `node:sqlite` was `experimental` in Node.js 22.x. gijun-ai uses it. Node 24 LTS has promoted it, but users on older `22.x` lines may see `ExperimentalWarning` logs.
-- If Node 22 LTS EOL arrives before Node 24 adoption catches up, gijun-ai may migrate to `better-sqlite3`.
+- `node:sqlite` was `experimental` in Node.js 22.x. policyloop uses it. Node 24 LTS has promoted it, but users on older `22.x` lines may see `ExperimentalWarning` logs.
+- If Node 22 LTS EOL arrives before Node 24 adoption catches up, policyloop may migrate to `better-sqlite3`.
 
 ## Third-party license compatibility
 
@@ -71,7 +71,7 @@ To audit transitive dependencies, run:
 npx license-checker --production --summary
 ```
 
-If a transitive dependency introduces a GPL-family license, the safe response is to pin an earlier version or find an alternative — **do not re-license gijun-ai to GPL** just to absorb a dependency.
+If a transitive dependency introduces a GPL-family license, the safe response is to pin an earlier version or find an alternative — **do not re-license policyloop to GPL** just to absorb a dependency.
 
 ## Archive / strand scenarios
 
@@ -81,7 +81,7 @@ If the maintainer steps away:
 - The repository may be archived (read-only). Archiving does not delete the history.
 - Open issues / PRs will get no response — see `CONTRIBUTING.md`.
 
-If you depend on gijun-ai for anything important, **mirror the repository** (`git clone --mirror`) and be prepared to fork if upstream goes silent.
+If you depend on policyloop for anything important, **mirror the repository** (`git clone --mirror`) and be prepared to fork if upstream goes silent.
 
 ## What this project does **not** promise
 

--- a/docs/project-framework.md
+++ b/docs/project-framework.md
@@ -1,6 +1,6 @@
 # Project Framework — 5 Axes of Concern
 
-> gijun-ai's concerns decompose into five orthogonal axes. Each axis has a
+> policyloop's concerns decompose into five orthogonal axes. Each axis has a
 > clear boundary rule for what belongs inside it. This avoids the original
 > 4-axis design's MECE violation where tests, CI, and plaform concerns were
 > all tangled under "reliability".

--- a/docs/public-status-dod.md
+++ b/docs/public-status-dod.md
@@ -1,6 +1,6 @@
 # Public Status — Definition of Done (DoD)
 
-> gijun-ai's level-based public status framework.
+> policyloop's level-based public status framework.
 >
 > Each level above L1 has a concrete, testable Definition of Done. A level is
 > claimed only when **every** checkbox is green — there is no "mostly L2" or
@@ -16,9 +16,9 @@
 | **L1** | Personal experiment | Code exists on disk / private | Anything public |
 | **L2** | Reference-only public | Code is public, reproducible, honestly labeled | Production adoption |
 | **L3** | PR-accepting | Community can contribute, bug reports are triaged | Team / RBAC / multi-user |
-| **L4** | Production-dependency-safe | **Out of scope for gijun-ai.** Fork required. | — (fork needed) |
+| **L4** | Production-dependency-safe | **Out of scope for policyloop.** Fork required. | — (fork needed) |
 
-gijun-ai's **current target is L2**. L3 is evaluated only after the v0.2 milestone. L4 is deliberately out of scope for this project (see `README.md` — "Out of scope (fork required)").
+policyloop's **current target is L2**. L3 is evaluated only after the v0.2 milestone. L4 is deliberately out of scope for this project (see `README.md` — "Out of scope (fork required)").
 
 ---
 
@@ -73,7 +73,7 @@ After the v0.2 milestone (E2E tests + CI matrix + OSS community assets shipped),
 
 ## L3 → L4: Production-dependency-safe — **Out of scope for this project**
 
-Reaching L4 requires multi-user authentication, RBAC, durable audit replication, 24-hour security-patch SLA, and formal compliance work (SOC2 / ISO27001 / etc.). These are all explicitly out of scope for gijun-ai.
+Reaching L4 requires multi-user authentication, RBAC, durable audit replication, 24-hour security-patch SLA, and formal compliance work (SOC2 / ISO27001 / etc.). These are all explicitly out of scope for policyloop.
 
 If you need L4-grade capabilities, **fork the project**. The MIT license allows this. The architecture is designed to be legible for adaptation in a single sitting — see `docs/project-framework.md` for the 5-axis framework that separates single-user scope from the parts that would need to be rewritten for team operation.
 


### PR DESCRIPTION
## Summary

PR #33 renamed external surface from `gijun-ai` to `policyloop` but missed 22 hits in user-facing documentation and GitHub templates. This PR completes the rename per audit findings.

README line 11 explicitly retains `gijun-ai` for: internal codename · directory / npm path · GitHub repo. But the policy does **not** cover `docs/`, `CONTRIBUTING.md`, or `.github/` templates that are visible to external users (GitHub UI exposure).

## Changes (36 occurrences across 8 files)

- `docs/legal.md` (13), `docs/public-status-dod.md` (4), `docs/project-framework.md` (1), `docs/adoption-scenarios.md` (7)
- `CONTRIBUTING.md` (4)
- `.github/pull_request_template.md` (1), `.github/ISSUE_TEMPLATE/bug_report.yml` (2), `.github/ISSUE_TEMPLATE/feature_request.yml` (4)

## Preserved (per README line 11 policy)

- `@gijun-ai/{core,server,web,mcp-server}` workspace package names
- GitHub repo URL (`aniboy2k-gif/gijun-AI`)
- Directory paths (`gijun-ai/...`)
- `README*` / `CHANGELOG.md` rename history annotations
- `packages/server/src/app.ts:29` backward-compat fallback

## Test plan

- [x] `pnpm test` in `packages/server` → 17/17 pass
- [x] `git diff --stat` → 36 insertions + 36 deletions (pure rename, no logic change)
- [ ] CI green on push

## Audit trail

Discovered via session audit triggered by user-pointed CI failure run #26218943353 (PR #33 1st commit, self-fixed in PR #33 2nd commit fb55f59504). User requested 유사 결함 일괄 점검 → docs/templates 22 hits 발견 → 본 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)