### PR TITLE
ci: expand claim-check trigger paths to cover docs & templates (CSR #756 옵션 B)

### DIFF
--- a/.github/workflows/claim-check.yml
+++ b/.github/workflows/claim-check.yml
@@ -10,6 +10,12 @@ on:
       - "packages/**"
       - ".github/claim-map.yml"
       - ".github/workflows/claim-check.yml"
+      # CSR #756 옵션 B (2026-05-22): branch protection 'Verify README claims match code'
+      # required check가 영원 pending되는 BLOCKED 결함 해소 (PR #37, #39 사건 후속).
+      - "docs/**"
+      - "CONTRIBUTING.md"
+      - ".github/pull_request_template.md"
+      - ".github/ISSUE_TEMPLATE/**"
   pull_request:
     paths:
       - "README.md"
@@ -18,6 +24,11 @@ on:
       - "packages/**"
       - ".github/claim-map.yml"
       - ".github/workflows/claim-check.yml"
+      # CSR #756 옵션 B (2026-05-22): branch protection BLOCKED 결함 해소
+      - "docs/**"
+      - "CONTRIBUTING.md"
+      - ".github/pull_request_template.md"
+      - ".github/ISSUE_TEMPLATE/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

CSR #756 옵션 B 채택 결과. PR #37·#39 에서 발견된 branch protection BLOCKED 결함 (workflow paths whitelist 누락) 구조적 해소.

## Root cause

`claim-check.yml` 의 `pull_request.paths` whitelist가 다음 경로 미포함:
- `docs/**`
- `CONTRIBUTING.md`
- `.github/pull_request_template.md`
- `.github/ISSUE_TEMPLATE/**`

해당 영역만 변경하는 PR은 workflow trigger 안 됨 → `Verify README claims match code` required check 영원 pending → `mergeStateStatus=BLOCKED`.

PR #37 (ops/.gitignore 변경), PR #39 (docs/templates rename) 모두 동일 패턴으로 `--admin override` 머지.

## 변경

`pull_request.paths` 와 `push.paths` 양쪽에 4 entry 추가 (총 11 lines):
- `docs/**`
- `CONTRIBUTING.md`
- `.github/pull_request_template.md`
- `.github/ISSUE_TEMPLATE/**`

## 점검 결과 (별건 결함 부재)

- `ci.yml`: `pull_request: branches: [main]` 만 명시 (paths 제약 없음). PR #37 BLOCKED root cause는 ci.yml이 아닌 다른 메커니즘일 가능성 — 본 PR scope 외 별도 분석 필요.
- 본 PR이 본인의 trigger paths (`.github/workflows/claim-check.yml`) 매칭 — 자기 참조 트리거로 claim-check 정상 발화 기대.

## Test plan

- [x] yaml syntax check (python yaml) PASS
- [x] git diff verify (paths 4 entry × 2 = 11 lines insertion)
- [ ] CI green on push (본 PR 자체가 claim-check trigger paths에 매칭, claim-check check 정상 발화 확인)
- [ ] mergeStateStatus = CLEAN (BLOCKED 아님) 확인 후 squash merge

## 관련

- CSR #756 (선행 결정 done, 2026-05-22)
- CSR #769 [작업-756-B] (본 작업 트래킹)
- PR #37 (BLOCKED 사례 #1, 2026-05-21)
- PR #39 (BLOCKED 사례 #2, 2026-05-22, mergeCommit `5a94230d38`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)