### PR TITLE
chore(release): v0.5.1 — hotfix HITL UI gate condition + axes shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to `policyloop` (formerly `gijun-ai`) are documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), semver.
 
+## [0.5.1] — 2026-05-22
+
+### Context
+
+Hotfix release for two HITL UI bugs discovered immediately after the
+v0.5.0 tag was pushed (CSR #755 — user decision option A).
+
+The v0.5.0 tag (`97efa01`) shipped the HITL approval button (PR #34) but
+the button never appeared in practice because the gate condition only
+checked `status === 'hitl_wait'`, while `createTask` returns `pending`
+for HITL-required tasks (the `hitl_required=1` flag is what marks them).
+PR #36, merged shortly after the tag, added the reject button and trigger
+reason display but inherited both the gate condition bug and a shape
+mismatch on `hitl_trigger.axes` (assumed `Array<{reason: string}>`,
+server returns `string[]`).
+
+Both bugs are fixed by PR #38, which is rolled up into v0.5.1.
+
+### Fixed
+
+- **HITL UI gate condition** (`packages/web/src/tabs/TasksTab.tsx`) —
+  approval/reject buttons now render when the task row has
+  `hitl_required === 1`, regardless of whether `status` is `pending` or
+  `hitl_wait`. Previously HITL-waiting tasks showed no buttons at all
+  (effectively dead UI). (#38)
+- **`hitl_trigger.axes` shape handling** (`packages/web/src/tabs/TasksTab.tsx`)
+  — `formatTrigger()` now treats `axes` as `string[]`, matching the
+  server-side `evaluateTaskHitl` return in `packages/core/src/hitl/gate.ts`.
+  The trigger reason now renders. (#38)
+
+### Tests
+
+- `packages/server/src/__tests__/rest-hitl-flow.e2e.test.ts` (+86 lines) —
+  two new e2e tests covering the HITL approval flow and the corrected
+  button-render condition. Server suite remains green (17/17 pass). (#38)
+
+### Notes
+
+- v0.5.0 tag is not retagged — preserves git history. CHANGELOG is the
+  canonical record. (CSR #755 option C rejected to avoid history rewrite.)
+- GitHub release notes for v0.5.0 unchanged per CSR #755 decision 3-B
+  (single-user project, external exposure minimal).
+
+---
+
 ## [0.5.0] — 2026-05-21
 
 ### Context

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "policyloop",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Personal single-user AI agent audit/verification workbench — 기준을 세우고, 검증하며, 학습한다",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Summary

v0.5.1 hotfix release. Rolls up PR #38 (merge `2b75cd4`) into a tagged release because the v0.5.0 tag shipped two HITL UI bugs that made the approval button effectively dead UI.

CSR #755 user decision (option A — v0.5.1 hotfix tag, **not** force re-tag).

## Background

- v0.5.0 tag (`97efa01`) included PR #34 (HITL approval button) but the button never appeared — gate condition was `status === 'hitl_wait'` while `createTask` returns `pending` for HITL tasks.
- PR #36 (reject button + reason display) merged after the tag, inheriting both the gate bug and a `hitl_trigger.axes` shape mismatch (assumed `Array<{reason}>`, server returns `string[]`).
- PR #38 fixed both. Already on `main`. This release just makes v0.5.1 the canonical version users should pin to.

## Changes

- `CHANGELOG.md` — new `[0.5.1] — 2026-05-22` entry (broken UI context, two `### Fixed` items, test count, notes on tag retention).
- `package.json` — `version: 0.5.0 → 0.5.1`.

No code changes. PR #38 (`2b75cd4`) is the actual code fix.

## Test plan

- [ ] CI green on this PR (release-tooling-only diff, no code touched)
- [ ] After merge, tag `v0.5.1` on the merge commit + `git push origin v0.5.1`
- [ ] `git fetch --tags` from a fresh clone shows `v0.5.1`

Refs: CSR #755 (Decision-2, option A) · CSR #770 (Work-E)