### PR TITLE
security: integrated fix from CSR #771 4-AI DA (11 fixes: C1+C2+H3+H4+H5+M6+L9·L10·L11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,45 @@ External 4-AI DA Tier 1 (security role) review is deferred to a follow-up
 session (CSR #758 user decision, 2026-05-22). Rate limiting (M1, ~5
 rotations / 10 min token bucket) is deferred to a separate CSR.
 
+#### Post-DA Hardening (CSR #771 → CSR #775)
+
+External 4-AI DA Tier 1 (security) verification (Gemini → ChatGPT → Claude
+Web → DeepSeek) discovered additional findings, integrated as PR #43:
+
+- **C1 (NEW CRITICAL — DeepSeek R4)** `AGENTGUARD_ENV_FILE` bypass via
+  `NODE_ENV=test` injection. `env-file.ts` now requires BOTH
+  `NODE_ENV=test` AND a valid `AGENTGUARD_TEST_MODE` HMAC token
+  (boot-epoch + TTL + HMAC-SHA256) for the override to be honored.
+- **C2 (NEW CRITICAL — DeepSeek R4)** HMAC key management for the test-mode
+  gate. New required env var `AGENTGUARD_CONFIG_HMAC_KEY` (production
+  fail-closed when missing). See `docs/migration-CSR-775.md` for setup.
+- **H3 (DeepSeek R4 H1)** Audit DB append-only OS flag —
+  `chflags uappnd` (macOS) / `chattr +a` (Linux) applied at boot via
+  `applyAppendOnlyFlagAtBoot()`. Production fail-closed on chattr failure.
+- **H4 (Claude Web R3-H1)** `crypto.timingSafeEqual` verification +
+  regression guard (AST grep + statistical timing test).
+- **H5 (Claude Web R3-H5)** `X-AgentGuard-CLI` header design — Option B
+  (header = path-hint, NOT auth). See `docs/threat-model-CSR-775.md`
+  for residual risk disclosure.
+- **M6 (Claude Web R3-M3)** Cluster guard correctness fix — proper
+  imports for `cluster.isWorker`, `isMainThread`, `process.send !== undefined`.
+  Fail-closed boot in cluster/worker_threads/forked-child topology.
+- **M7 (N/A — Claude Web R3-M2)** UA-based detection removal — code grep
+  confirmed 0 matches in `src/`. No-op.
+- **M8 (N/A — Claude Web R3-H3)** `fs.watch` symlink race — reload
+  mechanism not implemented; documented in threat-model for future work.
+
+Carry-forward (separate CSRs):
+- WORM external logging sink — CSR #777
+- DA infrastructure improvements (reject section / OWASP boundary docs /
+  enforceability tagging) — CSR #778
+- NTP-skew safe grace period (`performance.now()` monotonic) — separate CSR
+
+CWE coverage: CWE-352 (CSRF), CWE-916 (token hash), CWE-208 (timing),
+CWE-345 (data authenticity), CWE-330 (HMAC key origin), CWE-367 (TOCTOU),
+CWE-732 (incorrect permission), CWE-362 (race condition), CWE-664
+(resource lifetime).
+
 ### Test coverage
 
 - 11 new tests in `packages/server/src/__tests__/auth.rotate-token.e2e.test.ts`

--- a/docs/migration-CSR-775.md
+++ b/docs/migration-CSR-775.md
@@ -1,0 +1,240 @@
+# Migration Guide — CSR #775 (PR #43)
+
+생성일시: 2026-05-23
+출처: CSR #771 외부 4-AI Tier 1 (security) DA 검증 결과 통합 fix
+관련: CSR #775 (본 PR), CSR #758 (선행 PR #42 base)
+
+## 영향 요약 (TL;DR)
+
+| 변경 | 영향 | 조치 |
+|---|---|---|
+| **새 필수 환경변수** `AGENTGUARD_CONFIG_HMAC_KEY` | production NODE_ENV에서 미설정 시 boot abort | 키 생성 + 환경변수 등록 (아래 §1) |
+| **AGENTGUARD_ENV_FILE 사용 제한** | NODE_ENV=test + valid HMAC token 둘 다 필요 | 테스트 환경 setup 변경 (§2) |
+| **Cluster mode 차단** | `cluster.fork()`·worker_threads·child_process.fork 모두 boot abort | single-process 배포 보장 (§3) |
+| **Audit DB append-only flag** | production에서 chattr/chflags 실패 시 boot abort | DB 파일 OS-level 권한 확인 (§4) |
+| **Token comparison timing-safe** | 코드 변경 없음 (이미 적용 — regression test 추가) | — |
+| **X-AgentGuard-CLI header (Option B)** | header가 secret 아닌 path hint로 명시 | docs 변경만, code 변경 없음 |
+
+## 1. AGENTGUARD_CONFIG_HMAC_KEY (필수)
+
+### 1.1 영향 범위
+- `NODE_ENV=production` deployment 전체
+- 미설정 시 boot 시점에 즉시 에러:
+  ```
+  agentguard_config_hmac_key_required_in_production:
+    AGENTGUARD_CONFIG_HMAC_KEY env var must be set when NODE_ENV=production.
+  ```
+
+### 1.2 키 생성 (배포 환경에서 1회)
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# 출력 예: 64자 hex 문자열 (256-bit entropy)
+```
+
+### 1.3 환경변수 등록 방법별
+
+#### Vercel / Railway / Fly.io
+- 환경변수 UI에서 **Secret** 으로 등록 (로그 미노출)
+- 키: `AGENTGUARD_CONFIG_HMAC_KEY`
+- 값: 위에서 생성한 64자 hex
+
+#### Docker / docker-compose
+```yaml
+# docker-compose.yml
+services:
+  agentguard:
+    environment:
+      - NODE_ENV=production
+      - AGENTGUARD_CONFIG_HMAC_KEY  # 호스트 환경에서 inject
+    # 또는 secrets 사용:
+    secrets:
+      - agentguard_config_hmac_key
+```
+
+#### bare metal / systemd
+```ini
+# /etc/systemd/system/agentguard.service
+[Service]
+EnvironmentFile=/etc/agentguard/secret.env  # chmod 0600, owner=agentguard:agentguard
+```
+secret.env 파일:
+```
+AGENTGUARD_CONFIG_HMAC_KEY=<64자_hex>
+```
+
+### 1.4 검증
+
+```bash
+# 정상 boot 확인
+NODE_ENV=production AGENTGUARD_CONFIG_HMAC_KEY=<your_key> \
+  node packages/server/dist/server.js
+# 출력: [agentguard] server listening on http://127.0.0.1:3456
+
+# 네거티브 테스트 — 키 누락 시 즉시 throw
+NODE_ENV=production node packages/server/dist/server.js
+# 예상: throw "agentguard_config_hmac_key_required_in_production"
+# exit code: 1
+```
+
+### 1.5 키 로테이션 정책
+
+| 항목 | 권장 |
+|---|---|
+| 주기 | 90일 |
+| 절차 | 새 키 환경변수 추가 → graceful restart → 구 키 제거 |
+| 진행 중 토큰 영향 | 키 교체 시 AGENTGUARD_TEST_MODE 토큰 자동 invalidate (의도된 동작) |
+| 키 저장소 | HSM / KMS (AWS Secrets Manager, GCP Secret Manager, Vault) 권장 |
+
+### 1.6 비-production 환경 (개발 / test)
+
+- `NODE_ENV !== 'production'` (즉 `development` / `test`): HMAC_KEY 미설정 허용 (warning 로그 없음, silent)
+- 단, `AGENTGUARD_ENV_FILE` 사용 시는 **항상 필요** (C1 통합 검사)
+
+## 2. AGENTGUARD_ENV_FILE 사용 제한 (test 환경 setup 변경)
+
+### 2.1 변경 사항
+
+PR #43 이전:
+```bash
+# 이렇게만 하면 동작
+NODE_ENV=test AGENTGUARD_ENV_FILE=/tmp/test.env node ...
+```
+
+PR #43 이후:
+```bash
+# valid HMAC token도 함께 필요
+NODE_ENV=test \
+AGENTGUARD_CONFIG_HMAC_KEY=<test_key> \
+AGENTGUARD_ENV_FILE=/tmp/test.env \
+AGENTGUARD_TEST_MODE=$(node -e "
+  const { generateTestMode } = require('./packages/server/dist/auth/test-mode.js');
+  console.log(generateTestMode(Date.now() + 60_000));
+") \
+  node ...
+```
+
+### 2.2 테스트 코드 패턴
+
+테스트 setup 함수 (vitest/jest 등에 적용):
+```typescript
+import { generateTestMode } from '../auth/test-mode.js'
+
+// beforeAll
+process.env.AGENTGUARD_CONFIG_HMAC_KEY = require('crypto').randomBytes(32).toString('hex')
+process.env.NODE_ENV = 'test'
+
+// 각 test에서 env-file override 필요할 때
+process.env.AGENTGUARD_ENV_FILE = '/tmp/test.env'
+process.env.AGENTGUARD_TEST_MODE = generateTestMode(Date.now() + 60_000)
+```
+
+### 2.3 보안 근거 (DeepSeek R4 NEW CRITICAL 차단)
+
+이전 결함 (CVE-class):
+- `NODE_ENV=test` + `AGENTGUARD_ENV_FILE=<malicious>`만으로 production 우회
+- supply-chain env injection (docker/k8s) 통한 token theft 경로
+
+PR #43 적용 후:
+- `AGENTGUARD_CONFIG_HMAC_KEY`는 별도 secret manager로 보호 (token 파생 ❌)
+- `AGENTGUARD_TEST_MODE` token은 boot-epoch + TTL + HMAC-SHA256 → 재현·예측 불가
+
+## 3. Cluster mode 차단 (P4 M6)
+
+### 3.1 변경 사항
+
+PR #43에서 `assertSingleInstance()` boot 직후 호출. 다음 환경에서 즉시 throw:
+- `cluster.fork()` 로 spawn된 worker process
+- `worker_threads` 의 worker
+- `child_process.fork()` 로 spawn된 child (process.send 존재)
+
+### 3.2 영향받는 배포
+
+| 배포 패턴 | 영향 | 조치 |
+|---|---|---|
+| 단일 process (정상) | 영향 없음 | — |
+| PM2 cluster mode | **모든 worker boot abort** | exec_mode=fork로 변경 (single instance) |
+| Docker swarm replicas | 영향 없음 (각 container가 별도 process) | — |
+| Kubernetes Deployment replicas > 1 | 영향 없음 (각 pod가 별도 process) | — |
+| Node.js cluster module 사용 | **boot abort** | cluster mode 제거, 단일 process 또는 별도 pod scaling |
+
+### 3.3 향후 multi-process 지원
+
+별건 CSR로 분리됨 (Redis SETNX 또는 PostgreSQL advisory lock 도입 시).
+
+## 4. Audit DB Append-Only Flag (P7 H3)
+
+### 4.1 변경 사항
+
+`GIJUN_DB_PATH` 설정 시 boot 직후 OS append-only flag 적용:
+- **macOS**: `chflags uappnd <path>` (user-level, no sudo)
+- **Linux**: `chattr +a <path>` (root 또는 CAP_LINUX_IMMUTABLE)
+
+production에서 실패 시 boot abort. non-prod에서는 warning 후 continue.
+
+### 4.2 Linux 배포 시 권한 설정
+
+```bash
+# Option A: 권한 부여 (1회)
+setcap cap_linux_immutable+ep $(which node)
+
+# Option B: agentguard 사용자에 CAP 추가 (systemd)
+# /etc/systemd/system/agentguard.service
+[Service]
+AmbientCapabilities=CAP_LINUX_IMMUTABLE
+
+# Option C: root로 실행 (비권장 — 다른 보안 위험)
+```
+
+### 4.3 macOS 배포 시
+- 별도 권한 설정 불필요 (`chflags uappnd`는 user-level)
+
+### 4.4 영향: SQLite WAL mode 호환
+
+audit_events.db는 SQLite WAL mode 사용. append-only flag 적용 후에도:
+- WAL 파일 (`.db-wal`) write — 영향 없음 (flag는 main DB 파일에만 적용)
+- WAL checkpoint 시 main DB write — append만 발생하면 정상 동작
+- main DB 파일 삭제·truncate — flag로 차단 (의도된 보안 효과)
+
+운영자 주의:
+- DB 파일 삭제 또는 재생성 시 `chflags nouappnd` 또는 `chattr -a` 먼저 실행 필요
+- backup tool은 read-only access만 사용 (cp / rsync 정상 동작)
+
+## 5. 롤백 절차
+
+### 5.1 PR #43 revert
+```bash
+git revert <pr-43-commit-range>
+# 또는 main에서 PR #42 base로 reset
+git reset --hard 5507969
+```
+
+### 5.2 환경변수 정리
+```bash
+# 모두 제거 가능
+unset AGENTGUARD_CONFIG_HMAC_KEY
+unset AGENTGUARD_TEST_MODE
+```
+
+### 5.3 OS flag 해제
+```bash
+# macOS
+chflags nouappnd <audit-db-path>
+
+# Linux
+chattr -a <audit-db-path>
+```
+
+### 5.4 audit log hash-chain 호환
+
+- 기존 PR #42 base의 hash-chain (chain.ts + verify-chain.ts)은 그대로 유지
+- 롤백 후에도 verify 가능 (algorithm 변경 없음)
+- 단, append-only flag 해제 후에는 OS-level prevention 사라짐 (application-level hash-chain만 남음)
+
+## 6. References
+
+- 출처 DA: `/tmp/da-chain-1779432199/final.txt` (CSR #771 4-AI Tier 1 security)
+- Threat model: `docs/threat-model-CSR-775.md`
+- Plan: `prompt_plan.md` (LOCAL `.gitignore`, working plan)
+- 관련 CSR: #771 (DA verification), #775 (본 PR), #777 (carry-forward hardening), #778 (carry-forward DA infra)
+- CWE 매핑: §threat-model-CSR-775.md §7

--- a/docs/threat-model-CSR-775.md
+++ b/docs/threat-model-CSR-775.md
@@ -1,0 +1,158 @@
+# Threat Model — CSR #775 (PR #43 Integrated Security Hardening)
+
+생성일시: 2026-05-23
+출처: CSR #771 외부 4-AI Tier 1 (security) DA 검증 (Gemini → ChatGPT → Claude Web → DeepSeek)
+관련: CSR #758 (PR #42 Settings tab — base), CSR #775 (PR #43 — 본 문서)
+
+## 1. Threat Model Boundaries
+
+### 1.1 Attacker Classes (in-scope)
+
+| Class | 정의 | Capability |
+|---|---|---|
+| **(a) External web attacker** | 사용자가 방문한 악의 페이지 (CSRF, XSS) | 동일 출처 cookie 사용 못함 (SameSite=Strict). 가능: cross-origin fetch with simple headers / preflight 발생 시 차단됨 |
+| **(b) Malicious local user** | shell 접근 가진 같은 host 사용자 | env-var 설정·파일 시스템 접근·process inspection / 자신의 token rotation 가능 / **타 user의 process 메모리는 ptrace 권한 필요** |
+| **(c) Compromised sibling process** | Node.js cluster mode worker · worker_thread · forked child | 동일 process memory 공유 (worker_threads) 또는 별도 process (cluster.fork) / **cluster guard로 boot abort** (P4 M6 적용) |
+| **(d) Supply-chain via env-var injection** | orchestration layer (Docker/k8s/CI)에서 env-var 주입 | NODE_ENV·AGENTGUARD_TOKEN·AGENTGUARD_ENV_FILE 모든 env-var 제어 가능 / **AGENTGUARD_CONFIG_HMAC_KEY 필수 + AGENTGUARD_TEST_MODE HMAC로 차단** (P1 C2 + P2 C1 적용) |
+
+### 1.2 Trust Boundary
+
+- **현재**: 단일 Node.js process (single-instance, cluster guard로 강제)
+- **미래**: optional cluster + 공유 filesystem (별건 CSR — Redis SETNX 또는 PostgreSQL advisory lock)
+
+### 1.3 Deployment Topology
+
+```
+[End user CLI] ──┐
+                 ├─→ Node.js single-process ──→ SQLite (audit_events chain)
+[Web dashboard]──┘    ↓ listen 127.0.0.1:3456     ↓
+                     middleware/auth.ts            chain.ts (sha256 + verify-chain.ts)
+                     ↓
+                     token-holder.ts (HMAC-SHA256 + 5s grace)
+```
+
+- 모든 endpoint는 localhost (127.0.0.1) bind. 외부 노출 없음
+- web dashboard는 SameSite=Strict cookie 권고 (browser path)
+- CLI는 X-AgentGuard-Token header (인증) + X-AgentGuard-Confirm-Rotate (CSRF guard)
+
+### 1.4 Crown Jewels
+
+| 자원 | 보호 mechanism |
+|---|---|
+| `AGENTGUARD_TOKEN` (full API auth) | timing-safe compare (P6 H4 verified) + 5초 grace period + HMAC env-file gate (P1·P2) |
+| `.env.local` 파일 | atomic write (tmp + rename) + symlink check + chmod 0600 + AGENTGUARD_TEST_MODE HMAC gate |
+| `audit_events` chain | hash chain (prev_hash + content_hash + chain_hash sha256) + tamper detection (verify-chain.ts) + SQLite WAL mode |
+| `AGENTGUARD_CONFIG_HMAC_KEY` | production 필수 + 별도 env-var (token 파생 ❌) — migration guide 별도 |
+
+### 1.5 In-Scope Failures
+
+- Token theft (header / log / crash dump 통한 추출)
+- Audit chain manipulation (DB 직접 modify)
+- Configuration tampering (`.env.local`·NODE_ENV 우회)
+- CSRF (cross-origin POST)
+- **Localhost bind-race** — orchestration layer가 port ownership 검증 실패 시 in-scope (P9 L10 refinement)
+
+### 1.6 Out-of-Scope (PR #43)
+
+- Cross-host network MITM (localhost binding only)
+- Supply-chain at npm publish 시점 (별건 CSR — npm audit + provenance)
+- Hardware attacks (host compromise via firmware/BMC 등)
+
+## 2. F1 — X-AgentGuard-CLI Header (Plan v2 P5 H5 Option B)
+
+### 2.1 Decision: Option B (Header = Path-Hint, NOT Auth)
+
+CSR #771 R3 Claude Web M-R3-2 + DeepSeek H2 발견에 따라 X-AgentGuard-CLI header를 **secret 아닌 path-hint**로 사용. 인증은 token-only (`X-AgentGuard-Token` + timing-safe compare).
+
+```
+브라우저 경로:
+  fetch('/auth/rotate-token', {
+    method: 'POST',
+    headers: { 'X-AgentGuard-Token': token, 'X-AgentGuard-Confirm-Rotate': 'yes' },
+    credentials: 'include',
+  })
+  → SameSite=Strict cookie + Origin header 검증 (127.0.0.1/localhost) + token 인증
+
+CLI 경로:
+  curl -H 'X-AgentGuard-Token: <token>' -H 'X-AgentGuard-Confirm-Rotate: yes' \
+       http://127.0.0.1:3456/auth/rotate-token
+  → Origin header 없음 → CLI 식별 → 통과 (token 인증)
+```
+
+### 2.2 Residual Risks (Honest Disclosure)
+
+| Risk | 설명 | Mitigation |
+|---|---|---|
+| **Same-origin XSS → header set** | dashboard에 XSS 취약점 있으면 attacker JS가 X-AgentGuard-Token header 설정 가능 | CSP `default-src 'self'` + dashboard 컴포넌트 XSS-free 검증 + audit redaction 강화 |
+| **Local user (b) inspects token** | shell 접근자는 process env-var 또는 `.env.local` 파일 직접 read 가능 | 본 PR 범위 외 (host-level 격리 책임). chmod 0600 + audit log로 access 기록 |
+| **Cross-origin without preflight** | Simple POST (no custom headers, content-type=text/plain)는 preflight 회피 가능 | `X-AgentGuard-Confirm-Rotate: yes` 필수 → custom header → 모든 cross-origin POST는 preflight 강제 |
+| **Browser fetch credentials=omit** | credentials=omit인 cross-origin fetch는 cookie 미전송이지만 header만으로는 인증 불가 | token-only 인증이므로 영향 없음 |
+
+### 2.3 Architectural Note (Option A vs Option B 선택 이유)
+
+Option A (HMAC over nonce + LRU nonce store + 별도 key) 거부 사유:
+- nonce store 운영 부담 (single-instance 가정 위반 시 race)
+- HMAC 키 관리 복잡 (rotation·storage·leakage 위험)
+- 본질적으로 인증은 token이 담당 — header는 path 분기 hint
+- DeepSeek H2 발견: HMAC 키가 token 파생 시 brute-force 가능 → 별도 key 도입 시 또 다른 secret 관리 필요
+
+**KISS 원칙 (golden-principles.md)**: 불필요한 abstraction 회피. Header는 hint, 인증은 token.
+
+## 3. F2 — Audit Log Hardening (Plan v2 P7 H3)
+
+### 3.1 현재 mechanism
+
+- **Application layer**: hash chain (sha256 prev/original/content/chain) — tamper detection
+- **Database layer**: SQLite WAL mode + chmod 0600
+- **OS layer**: ⚠️ chattr/chflags **미적용** (현재 0건 호출 — P7 H3 신규 도입)
+
+### 3.2 P7 H3 신규 — OS append-only flag
+
+```
+Linux:  chattr +a <audit-db-path>     (root 권한 또는 CAP_LINUX_IMMUTABLE 필요)
+macOS:  chflags uappnd <audit-db-path> (user-level 가능)
+```
+
+production NODE_ENV에서 chattr 실패 → boot abort (`audit_append_only_flag_failed`).
+non-prod에서 chattr 실패 → warning log + continue (dev 환경 제약).
+
+### 3.3 Residual Risks
+
+| Risk | Mitigation |
+|---|---|
+| **Root user (attacker class b 변형)** | chattr -a로 flag 제거 가능 — host-level 격리 책임 외 |
+| **WORM external sink 미적용** | CSR #777 carry-forward (별건 hardening CSR) |
+| **chain repair by chain attack** | hash chain은 tamper detection만, prevention은 OS flag 의존 |
+
+## 4. F3 — Single-Instance Invariant (Plan v2 P4 M6, ✅ done)
+
+cluster mode·worker_threads·child_process.fork 모두 boot abort. Multi-process 미래는 Redis SETNX 또는 PostgreSQL advisory lock (별건 CSR).
+
+## 5. F4 — Token Rotation 5s Grace (CSR #758 base, CSR #771 R3 M-R3-3 NOT applied here)
+
+- 현재: `Date.now()` 기반 5초 grace (token-holder.ts line 4 + 49)
+- 결함: NTP-skew 영향 가능 (CSR #771 R3 M-R3-3)
+- 본 PR에서 fix 미적용 — **별건 CSR carry-forward** (사용자 결정 (B) 답습, CSR #777에 포함 가능)
+
+## 6. F5 — Configuration Tampering (Plan v2 P1+P2, ✅ done)
+
+- **C1 (P2 ✅)**: env-file 로드 시 NODE_ENV + AGENTGUARD_TEST_MODE HMAC 통합 검증
+- **C2 (P1 ✅)**: AGENTGUARD_CONFIG_HMAC_KEY 필수 + boot-epoch anti-replay + TTL
+- **L11 (P9 예정)**: CWD allowlist (Plan v1) → AGENTGUARD_TEST_MODE HMAC env var (Plan v2 통합)
+
+## 7. References
+
+- 출처 DA: `/tmp/da-chain-1779432199/final.txt` (CSR #771 4-AI Tier 1 security)
+- CWE 매핑: CWE-352 (CSRF) · CWE-916 (token hash) · CWE-208 (timing side-channel) · CWE-345 (data authenticity) · CWE-330 (HMAC key origin) · CWE-367 (TOCTOU) · CWE-732 (incorrect permission) · CWE-807 (untrusted input — N/A, UA 분기 없음)
+- OWASP: A01 (Broken Access Control) · A04 (Insecure Design) · A05 (Insecure Configuration) · A07 (Insufficient Logging)
+- Plan: `prompt_plan.md` (LOCAL `.gitignore`된 작업 계획)
+- Migration guide: `docs/migration-CSR-775.md` (P10에서 신설)
+
+## 8. Future Work (Out-of-PR-43 Carry-Forward)
+
+- WORM external logging sink — CSR #777
+- Multi-process token rotation (Redis SETNX) — 별건 CSR
+- NTP-skew safe grace period (performance.now() monotonic) — 별건 CSR
+- DA template "reject section" 의무 — CSR #778
+- OWASP A01/A05 boundary docs — CSR #778
+- Mitigation enforceability tagging — CSR #778

--- a/docs/threat-model-CSR-775.md
+++ b/docs/threat-model-CSR-775.md
@@ -140,6 +140,21 @@ cluster mode·worker_threads·child_process.fork 모두 boot abort. Multi-proces
 - **C2 (P1 ✅)**: AGENTGUARD_CONFIG_HMAC_KEY 필수 + boot-epoch anti-replay + TTL
 - **L11 (P9 예정)**: CWD allowlist (Plan v1) → AGENTGUARD_TEST_MODE HMAC env var (Plan v2 통합)
 
+### 6.1 P8 M8 — fs.watch symlink race (N/A 박제)
+
+**결정**: 본 PR scope에서 **N/A** — fs.watch / SIGHUP reload mechanism 자체가 미구현.
+
+근거:
+- 현재 `env-file.ts`는 `resolveEnvFilePath()`로 boot 시점 1회 path 확인 + `persistTokenToEnvFile()`로 token rotation 시점에 write
+- reload 또는 fs.watch handler 코드 미존재 → symlink race가 발생할 surface 자체가 없음
+- R3 Claude Web R3-H3 권고는 "boot-once + fs.watch + SIGHUP" 패턴 — 신규 reload 기능 도입 시 적용할 hardening 가이드
+
+향후 reload 도입 시 답습 권고:
+1. boot 시점 `lstat` + `isSymbolicLink()` 체크 → throw `env_file_symlink_blocked` (이미 `persistTokenToEnvFile`에 구현됨, line 84)
+2. `fs.watch` handler에 hash 재검증 추가 — content read 후 sha256 비교, mismatch → fail-closed
+3. SIGHUP signal handler로 명시적 reload 요청만 허용 (silent re-read 금지)
+4. `flock` advisory lock + read-fd + fstat 패턴으로 TOCTOU window 차단
+
 ## 7. References
 
 - 출처 DA: `/tmp/da-chain-1779432199/final.txt` (CSR #771 4-AI Tier 1 security)

--- a/packages/core/src/__tests__/redaction-key-name.test.ts
+++ b/packages/core/src/__tests__/redaction-key-name.test.ts
@@ -71,3 +71,23 @@ test('redactPayload: key "refresh_token" / "access_token" redacted', () => {
   assert.equal(out.refresh_token, '[REDACTED]')
   assert.equal(out.access_token, '[REDACTED]')
 })
+
+// CSR #775 H-INT-2: AGENTGUARD_CONFIG_HMAC_KEY parity with other secrets
+test('redactPayload: key "hmac_key" / "agentguard_config_hmac_key" / "config_hmac_key" redacted', () => {
+  const out = redactPayload({
+    hmac_key: HEX_TOKEN,
+    agentguard_config_hmac_key: HEX_TOKEN,
+    config_hmac_key: HEX_TOKEN,
+  }) as Record<string, unknown>
+  assert.equal(out.hmac_key, '[REDACTED]')
+  assert.equal(out.agentguard_config_hmac_key, '[REDACTED]')
+  assert.equal(out.config_hmac_key, '[REDACTED]')
+})
+
+test('redactPayload: nested hmac-key variants redacted', () => {
+  const out = redactPayload({
+    auth: { hmac_key: HEX_TOKEN, 'hmac-key': HEX_TOKEN },
+  }) as { auth: Record<string, unknown> }
+  assert.equal(out.auth['hmac_key'], '[REDACTED]')
+  assert.equal(out.auth['hmac-key'], '[REDACTED]')
+})

--- a/packages/core/src/audit/service.ts
+++ b/packages/core/src/audit/service.ts
@@ -28,7 +28,9 @@ const REDACTED_PLACEHOLDER = '[REDACTED]'
 // Key-name patterns: any payload key matching these is redacted regardless of
 // value shape. Covers high-entropy secrets that value-pattern regex misses
 // (e.g., lowercase hex tokens like AGENTGUARD_TOKEN).
-const REDACT_KEY_PATTERN = /(^|_)(token|secret|password|api[_-]?key|authorization|cookie|session[_-]?id|refresh[_-]?token|access[_-]?token)$/i
+// H-INT-2 (Internal review fix): hmac[_-]?key added — AGENTGUARD_CONFIG_HMAC_KEY
+// parity with other secrets (managed via KMS/HSM per docs/migration-CSR-775.md §1).
+const REDACT_KEY_PATTERN = /(^|_)(token|secret|password|api[_-]?key|authorization|cookie|session[_-]?id|refresh[_-]?token|access[_-]?token|hmac[_-]?key)$/i
 
 function redactString(s: string): string {
   let result = s

--- a/packages/server/src/__tests__/append-only-flag.test.ts
+++ b/packages/server/src/__tests__/append-only-flag.test.ts
@@ -1,0 +1,92 @@
+// RED skeleton for CSR #775 P7 H3: chattr/chflags append-only flag 신규
+// Plan v2 reference: ~/workspace/gijun-ai/prompt_plan.md §P7
+// Note: audit/append-only-flag.ts does not exist yet — RED at import time
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import os from 'node:os'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Module under test
+const mod = await import('../audit/append-only-flag.js')
+const {
+  applyAppendOnlyFlag,
+  applyAppendOnlyFlagSafe,
+  AppendOnlyFlagError,
+  isSupported,
+} = mod
+
+const TMP_DIR = mkdtempSync(resolve(tmpdir(), 'gijun-h3-test-'))
+process.on('exit', () => {
+  try {
+    rmSync(TMP_DIR, { recursive: true, force: true })
+  } catch {
+    /* best-effort */
+  }
+})
+
+test('H3: isSupported returns true on darwin/linux, false elsewhere', () => {
+  const result = isSupported()
+  if (os.platform() === 'darwin' || os.platform() === 'linux') {
+    assert.equal(result, true, `${os.platform()} must be supported`)
+  } else {
+    assert.equal(result, false)
+  }
+})
+
+test('H3: AppendOnlyFlagError has correct shape', () => {
+  const err = new AppendOnlyFlagError('test reason')
+  assert.ok(err instanceof Error)
+  assert.equal(err.name, 'AppendOnlyFlagError')
+  assert.equal(err.reason, 'test reason')
+  assert.match(err.message, /audit_append_only_flag_failed/)
+})
+
+test('H3: applyAppendOnlyFlag throws on non-existent path', () => {
+  assert.throws(
+    () => applyAppendOnlyFlag('/nonexistent/path/db.sqlite'),
+    (err: unknown) => {
+      assert.ok(err instanceof AppendOnlyFlagError)
+      assert.match(
+        (err as InstanceType<typeof AppendOnlyFlagError>).reason,
+        /file not found|not.*exist|ENOENT/i,
+      )
+      return true
+    },
+  )
+})
+
+test('H3: applyAppendOnlyFlagSafe returns {applied:false, reason} on non-existent', () => {
+  const result = applyAppendOnlyFlagSafe('/nonexistent/path/db.sqlite')
+  assert.equal(result.applied, false)
+  assert.ok(typeof result.reason === 'string' && result.reason.length > 0)
+})
+
+test('H3: applyAppendOnlyFlagSafe returns {applied:true} on real file (best-effort)', () => {
+  // macOS: chflags uappnd works at user level
+  // Linux: chattr +a requires root or CAP_LINUX_IMMUTABLE — may fail in CI
+  const dbPath = resolve(TMP_DIR, 'test-db.sqlite')
+  writeFileSync(dbPath, 'fake db content')
+  const result = applyAppendOnlyFlagSafe(dbPath)
+  if (os.platform() === 'darwin') {
+    assert.equal(result.applied, true, `chflags uappnd should succeed on macOS: ${result.reason ?? ''}`)
+  } else if (os.platform() === 'linux') {
+    // chattr +a may fail without root — accept both outcomes, but reason must be set on failure
+    if (!result.applied) {
+      assert.ok(result.reason, 'Linux failure must include reason')
+    }
+  } else {
+    // unsupported platform
+    assert.equal(result.applied, false)
+  }
+})
+
+test('H3: applyAppendOnlyFlag throws on unsupported platform (mocked)', () => {
+  // Cannot easily mock os.platform() — skip on supported platforms
+  // This test documents the requirement; actual cross-platform test is integration-level
+  if (!isSupported()) {
+    assert.throws(() => applyAppendOnlyFlag('/tmp/whatever'), AppendOnlyFlagError)
+  }
+})

--- a/packages/server/src/__tests__/auth.rotate-token.e2e.test.ts
+++ b/packages/server/src/__tests__/auth.rotate-token.e2e.test.ts
@@ -1,5 +1,6 @@
 import { test, before, after, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, resolve } from 'node:path'
@@ -12,11 +13,17 @@ const INITIAL_TOKEN = 'test-token-rotate-initial'
 const TMP_DIR = mkdtempSync(resolve(tmpdir(), 'gijun-rotate-test-'))
 const ENV_FILE = resolve(TMP_DIR, '.env.local')
 
+// CSR #775 P2 C1: AGENTGUARD_ENV_FILE 사용 시 HMAC token도 필요
 process.env['NODE_ENV'] = 'test'
 process.env['GIJUN_DB_PATH'] = ':memory:'
 process.env['GIJUN_MIGRATIONS_PATH'] = resolve(__dirname, '../../../../migrations')
 process.env['AGENTGUARD_TOKEN'] = INITIAL_TOKEN
+process.env['AGENTGUARD_CONFIG_HMAC_KEY'] = crypto.randomBytes(32).toString('hex')
 process.env['AGENTGUARD_ENV_FILE'] = ENV_FILE
+
+// test-mode must be imported BEFORE env-file for HMAC_KEY capture
+const testMode = await import('../auth/test-mode.js')
+process.env['AGENTGUARD_TEST_MODE'] = testMode.generateTestMode(Date.now() + 600_000) // 10min TTL
 
 const { createApp } = await import('../app.js')
 const core = await import('@gijun-ai/core')
@@ -44,6 +51,8 @@ after(async () => {
   delete process.env['GIJUN_MIGRATIONS_PATH']
   delete process.env['AGENTGUARD_TOKEN']
   delete process.env['AGENTGUARD_ENV_FILE']
+  delete process.env['AGENTGUARD_CONFIG_HMAC_KEY']
+  delete process.env['AGENTGUARD_TEST_MODE']
 })
 
 beforeEach(() => {

--- a/packages/server/src/__tests__/cluster-guard.test.ts
+++ b/packages/server/src/__tests__/cluster-guard.test.ts
@@ -1,0 +1,40 @@
+// RED skeleton for CSR #775 P4 M6: cluster guard 신규 도입
+// Plan v2 reference: ~/workspace/gijun-ai/prompt_plan.md §P4
+// Note: cluster-guard.ts does not exist yet — these tests should FAIL at import time
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+// Module under test — RED: file does not exist yet
+const clusterGuardMod = await import('../auth/cluster-guard.js')
+const { assertSingleInstance, isClusterWorker, isWorkerThread, isForkedChild } =
+  clusterGuardMod
+
+test('M6: standalone process passes assertSingleInstance() without throwing', () => {
+  // This test runs in standalone test runner (node --test) — should pass
+  assert.doesNotThrow(() => assertSingleInstance())
+})
+
+test('M6: isClusterWorker returns false in standalone process', () => {
+  assert.equal(isClusterWorker(), false)
+})
+
+test('M6: isWorkerThread returns false in main thread (standalone)', () => {
+  assert.equal(isWorkerThread(), false)
+})
+
+test('M6: isForkedChild returns false in standalone process', () => {
+  // node --test runs as standalone, process.send should be undefined
+  assert.equal(isForkedChild(), false)
+})
+
+test('M6: assertSingleInstance error message contains "cluster_unsafe" prefix', () => {
+  // Simulate by directly testing error format expectations
+  // (Real cluster/worker/fork tests would require child_process — separate integration test)
+  const result = clusterGuardMod
+  // Verify export shape
+  assert.equal(typeof result.assertSingleInstance, 'function')
+  assert.equal(typeof result.isClusterWorker, 'function')
+  assert.equal(typeof result.isWorkerThread, 'function')
+  assert.equal(typeof result.isForkedChild, 'function')
+})

--- a/packages/server/src/__tests__/env-file-integration.test.ts
+++ b/packages/server/src/__tests__/env-file-integration.test.ts
@@ -1,0 +1,116 @@
+// RED skeleton for CSR #775 P2 C1: env-file.ts integration with AGENTGUARD_TEST_MODE HMAC
+// Plan v2 reference: ~/workspace/gijun-ai/prompt_plan.md §P2
+// Note: env-file.ts currently allows AGENTGUARD_ENV_FILE when NODE_ENV=test only.
+// After C1 fix, it MUST additionally require valid AGENTGUARD_TEST_MODE HMAC token.
+
+import { test, before, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+
+// Set env BEFORE any module import that captures process.env at load time
+process.env['NODE_ENV'] = 'test'
+process.env['AGENTGUARD_CONFIG_HMAC_KEY'] =
+  crypto.randomBytes(32).toString('hex')
+
+const TMP_DIR = mkdtempSync(resolve(tmpdir(), 'gijun-c1-test-'))
+const TEST_ENV_FILE = resolve(TMP_DIR, '.env.local')
+writeFileSync(TEST_ENV_FILE, 'AGENTGUARD_TOKEN=initial\n')
+
+// Dynamic import after env setup
+const { generateTestMode } = await import('../auth/test-mode.js')
+const envFileMod = await import('../auth/env-file.js')
+const { resolveEnvFilePath, EnvFileError } = envFileMod
+
+beforeEach(() => {
+  delete process.env['AGENTGUARD_ENV_FILE']
+  delete process.env['AGENTGUARD_TEST_MODE']
+})
+
+afterEach(() => {
+  delete process.env['AGENTGUARD_ENV_FILE']
+  delete process.env['AGENTGUARD_TEST_MODE']
+})
+
+before(() => {
+  // Module loaded in test mode — verify
+  assert.equal(process.env['NODE_ENV'], 'test')
+  assert.ok(process.env['AGENTGUARD_CONFIG_HMAC_KEY'])
+})
+
+// Cleanup TMP_DIR at process exit
+process.on('exit', () => {
+  try {
+    rmSync(TMP_DIR, { recursive: true, force: true })
+  } catch {
+    /* best-effort */
+  }
+})
+
+test('C1: AGENTGUARD_ENV_FILE without HMAC token in test env → throws', () => {
+  process.env['AGENTGUARD_ENV_FILE'] = TEST_ENV_FILE
+  // No AGENTGUARD_TEST_MODE — should throw
+  assert.throws(
+    () => resolveEnvFilePath(),
+    (err: unknown) => {
+      assert.ok(err instanceof EnvFileError)
+      assert.match(
+        (err as InstanceType<typeof EnvFileError>).code,
+        /env_file_override_missing_valid_hmac|env_file_override_missing_hmac/,
+        'must throw HMAC-missing error code',
+      )
+      return true
+    },
+    'AGENTGUARD_ENV_FILE without HMAC token must throw',
+  )
+})
+
+test('C1: AGENTGUARD_ENV_FILE with invalid HMAC token in test env → throws', () => {
+  process.env['AGENTGUARD_ENV_FILE'] = TEST_ENV_FILE
+  process.env['AGENTGUARD_TEST_MODE'] = 'invalid.hmac-token-forged'
+  assert.throws(
+    () => resolveEnvFilePath(),
+    (err: unknown) => {
+      assert.ok(err instanceof EnvFileError)
+      assert.match(
+        (err as InstanceType<typeof EnvFileError>).code,
+        /env_file_override_invalid_hmac|env_file_override_missing_valid_hmac/,
+        'must throw invalid-HMAC error code',
+      )
+      return true
+    },
+    'AGENTGUARD_ENV_FILE with invalid HMAC token must throw',
+  )
+})
+
+test('C1: AGENTGUARD_ENV_FILE with valid HMAC token in test env → returns path', () => {
+  process.env['AGENTGUARD_ENV_FILE'] = TEST_ENV_FILE
+  process.env['AGENTGUARD_TEST_MODE'] = generateTestMode(Date.now() + 60_000)
+  const path = resolveEnvFilePath()
+  assert.equal(path, TEST_ENV_FILE, 'valid HMAC must allow path resolution')
+})
+
+test('C1: No AGENTGUARD_ENV_FILE → returns default .env.local in cwd', () => {
+  const path = resolveEnvFilePath()
+  assert.match(path, /\.env\.local$/, 'must end with .env.local')
+})
+
+test('C1: AGENTGUARD_ENV_FILE with expired HMAC token → throws', () => {
+  process.env['AGENTGUARD_ENV_FILE'] = TEST_ENV_FILE
+  process.env['AGENTGUARD_TEST_MODE'] = generateTestMode(Date.now() - 1000) // expired
+  assert.throws(
+    () => resolveEnvFilePath(),
+    (err: unknown) => {
+      assert.ok(err instanceof EnvFileError)
+      assert.match(
+        (err as InstanceType<typeof EnvFileError>).code,
+        /env_file_override_invalid_hmac|env_file_override_missing_valid_hmac/,
+        'expired HMAC token must throw',
+      )
+      return true
+    },
+    'AGENTGUARD_ENV_FILE with expired HMAC must throw',
+  )
+})

--- a/packages/server/src/__tests__/test-mode-weak-key.test.ts
+++ b/packages/server/src/__tests__/test-mode-weak-key.test.ts
@@ -1,0 +1,27 @@
+// CSR #775 H-INT-3: HMAC_KEY weak-key brute-force resistance
+// Internal review fix: AGENTGUARD_CONFIG_HMAC_KEY < 32 chars throws at module load.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+// Set short HMAC_KEY BEFORE module import — module-level check should throw
+process.env['NODE_ENV'] = 'test'
+process.env['AGENTGUARD_CONFIG_HMAC_KEY'] = 'short' // 5 chars, < 32 minimum
+
+test('H-INT-3: test-mode.ts throws on HMAC_KEY < 32 chars at module load', async () => {
+  await assert.rejects(
+    async () => {
+      await import('../auth/test-mode.js')
+    },
+    (err: unknown) => {
+      assert.ok(err instanceof Error)
+      assert.match(
+        (err as Error).message,
+        /agentguard_config_hmac_key_too_short|256-bit entropy|at least 32 chars/i,
+        'must throw weak-key error with descriptive message',
+      )
+      return true
+    },
+    'short HMAC_KEY (5 chars) must throw at module load',
+  )
+})

--- a/packages/server/src/__tests__/test-mode.test.ts
+++ b/packages/server/src/__tests__/test-mode.test.ts
@@ -1,0 +1,88 @@
+// RED skeleton for CSR #775 P1 C2: AGENTGUARD_TEST_MODE HMAC Key Management
+// Plan v2 reference: ~/workspace/gijun-ai/prompt_plan.md §P1
+// Note: auth/test-mode.ts does not exist yet — these tests should FAIL at import time
+
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+
+process.env['NODE_ENV'] = 'test'
+process.env['AGENTGUARD_CONFIG_HMAC_KEY'] =
+  crypto.randomBytes(32).toString('hex')
+
+// Module under test — RED: file does not exist yet
+const testModeMod = await import('../auth/test-mode.js')
+const { validTestMode, generateTestMode, getBootEpoch } = testModeMod
+
+test('validTestMode: returns false when token is undefined', () => {
+  assert.equal(validTestMode(undefined), false)
+})
+
+test('validTestMode: returns false when token is empty string', () => {
+  assert.equal(validTestMode(''), false)
+})
+
+test('validTestMode: returns true for valid token with current boot_epoch', () => {
+  const ttlMs = Date.now() + 60_000
+  const token = generateTestMode(ttlMs)
+  assert.equal(validTestMode(token), true)
+})
+
+test('validTestMode: returns false for replay token (different boot_epoch)', () => {
+  // Simulate previous boot by manually crafting payload with old epoch
+  const HMAC_KEY = process.env['AGENTGUARD_CONFIG_HMAC_KEY']!
+  const oldEpoch = getBootEpoch() - 1000 // 1 sec before current boot
+  const payload = Buffer.from(
+    JSON.stringify({ epoch: oldEpoch, ttl: Date.now() + 60_000 })
+  ).toString('base64')
+  const signature = crypto
+    .createHmac('sha256', HMAC_KEY)
+    .update(payload)
+    .digest('hex')
+  const token = `${payload}.${signature}`
+  assert.equal(validTestMode(token), false, 'replay must be rejected')
+})
+
+test('validTestMode: returns false for expired TTL', () => {
+  const expiredTtl = Date.now() - 1000 // already expired
+  const token = generateTestMode(expiredTtl)
+  assert.equal(validTestMode(token), false, 'expired TTL must be rejected')
+})
+
+test('validTestMode: returns false for tampered signature', () => {
+  const ttlMs = Date.now() + 60_000
+  const token = generateTestMode(ttlMs)
+  const [payload] = token.split('.')
+  // Forge signature with wrong key
+  const wrongKey = crypto.randomBytes(32).toString('hex')
+  const forgedSig = crypto
+    .createHmac('sha256', wrongKey)
+    .update(payload!)
+    .digest('hex')
+  const forgedToken = `${payload}.${forgedSig}`
+  assert.equal(validTestMode(forgedToken), false, 'tampered signature must be rejected')
+})
+
+test('validTestMode: returns false for malformed token (missing dot)', () => {
+  assert.equal(validTestMode('malformed-no-dot'), false)
+})
+
+test('validTestMode: returns false for malformed token (empty payload)', () => {
+  assert.equal(validTestMode('.signature-only'), false)
+})
+
+test('getBootEpoch: returns a number (monotonic boot counter)', () => {
+  const epoch = getBootEpoch()
+  assert.equal(typeof epoch, 'number')
+  assert.ok(epoch > 0)
+})
+
+test('generateTestMode: returns a string in payload.signature format', () => {
+  const ttlMs = Date.now() + 60_000
+  const token = generateTestMode(ttlMs)
+  assert.equal(typeof token, 'string')
+  const parts = token.split('.')
+  assert.equal(parts.length, 2, 'token must be payload.signature format')
+  assert.ok(parts[0]!.length > 0, 'payload must be non-empty')
+  assert.equal(parts[1]!.length, 64, 'signature must be sha256 hex (64 chars)')
+})

--- a/packages/server/src/__tests__/test-mode.test.ts
+++ b/packages/server/src/__tests__/test-mode.test.ts
@@ -85,6 +85,8 @@ test('generateTestMode: returns a string in payload.signature format', () => {
   assert.equal(typeof token, 'string')
   const parts = token.split('.')
   assert.equal(parts.length, 2, 'token must be payload.signature format')
-  assert.ok(parts[0]?.length > 0, 'payload must be non-empty')
-  assert.equal(parts[1]?.length, 64, 'signature must be sha256 hex (64 chars)')
+  const [payload, signature] = parts
+  if (!payload || !signature) throw new Error('test setup error: parts incomplete')
+  assert.ok(payload.length > 0, 'payload must be non-empty')
+  assert.equal(signature.length, 64, 'signature must be sha256 hex (64 chars)')
 })

--- a/packages/server/src/__tests__/test-mode.test.ts
+++ b/packages/server/src/__tests__/test-mode.test.ts
@@ -2,7 +2,7 @@
 // Plan v2 reference: ~/workspace/gijun-ai/prompt_plan.md §P1
 // Note: auth/test-mode.ts does not exist yet — these tests should FAIL at import time
 
-import { test, before, after } from 'node:test'
+import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import crypto from 'node:crypto'
 
@@ -30,7 +30,8 @@ test('validTestMode: returns true for valid token with current boot_epoch', () =
 
 test('validTestMode: returns false for replay token (different boot_epoch)', () => {
   // Simulate previous boot by manually crafting payload with old epoch
-  const HMAC_KEY = process.env['AGENTGUARD_CONFIG_HMAC_KEY']!
+  const HMAC_KEY = process.env['AGENTGUARD_CONFIG_HMAC_KEY']
+  if (!HMAC_KEY) throw new Error('test setup error: HMAC_KEY missing')
   const oldEpoch = getBootEpoch() - 1000 // 1 sec before current boot
   const payload = Buffer.from(
     JSON.stringify({ epoch: oldEpoch, ttl: Date.now() + 60_000 })
@@ -53,11 +54,12 @@ test('validTestMode: returns false for tampered signature', () => {
   const ttlMs = Date.now() + 60_000
   const token = generateTestMode(ttlMs)
   const [payload] = token.split('.')
+  if (!payload) throw new Error('test setup error: payload missing')
   // Forge signature with wrong key
   const wrongKey = crypto.randomBytes(32).toString('hex')
   const forgedSig = crypto
     .createHmac('sha256', wrongKey)
-    .update(payload!)
+    .update(payload)
     .digest('hex')
   const forgedToken = `${payload}.${forgedSig}`
   assert.equal(validTestMode(forgedToken), false, 'tampered signature must be rejected')
@@ -83,6 +85,6 @@ test('generateTestMode: returns a string in payload.signature format', () => {
   assert.equal(typeof token, 'string')
   const parts = token.split('.')
   assert.equal(parts.length, 2, 'token must be payload.signature format')
-  assert.ok(parts[0]!.length > 0, 'payload must be non-empty')
-  assert.equal(parts[1]!.length, 64, 'signature must be sha256 hex (64 chars)')
+  assert.ok(parts[0]?.length > 0, 'payload must be non-empty')
+  assert.equal(parts[1]?.length, 64, 'signature must be sha256 hex (64 chars)')
 })

--- a/packages/server/src/__tests__/timing-attack.test.ts
+++ b/packages/server/src/__tests__/timing-attack.test.ts
@@ -1,0 +1,128 @@
+// CSR #775 P6 H4: timingSafeEqual verification + regression guard
+// Plan v2 reference: ~/workspace/gijun-ai/prompt_plan.md §P6
+// Note: timing-safe comparison is already implemented in auth/token-holder.ts.
+// This file documents the requirement and prevents regression.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { isTokenValid, _resetForTests } from '../auth/token-holder.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+// __dirname at runtime = dist-test/__tests__/ — go up two levels to package root, then src/
+const TOKEN_HOLDER_PATH = resolve(
+  __dirname,
+  '../../src/auth/token-holder.ts',
+)
+
+// ---------------------------------------------------------------------------
+// AST/grep regression guard — token-holder.ts must NOT use `===` for token compare
+// ---------------------------------------------------------------------------
+
+test('H4 regression guard: token-holder.ts imports timingSafeEqual', () => {
+  const src = readFileSync(TOKEN_HOLDER_PATH, 'utf-8')
+  assert.match(
+    src,
+    /import\s*\{[^}]*\btimingSafeEqual\b[^}]*\}\s*from\s*['"]node:crypto['"]/,
+    'token-holder.ts must import timingSafeEqual from node:crypto',
+  )
+})
+
+test('H4 regression guard: token-holder.ts uses timingSafeEqual (no naive ===)', () => {
+  const src = readFileSync(TOKEN_HOLDER_PATH, 'utf-8')
+  // Extract the safeCompare function body (between { and matching })
+  const fnMatch = src.match(/function\s+safeCompare\b[\s\S]*?\n\}/)
+  assert.ok(fnMatch, 'safeCompare function must exist')
+  const body = fnMatch[0]
+  // Must contain timingSafeEqual call
+  assert.match(body, /timingSafeEqual\s*\(/, 'safeCompare must call timingSafeEqual')
+  // Must NOT contain naive === comparison on the tokens themselves
+  // (length comparison with === is OK and necessary)
+  const tokenCompareEquals = body.match(/\b(provided|expected|currentToken|previousToken|a|b)\s*===\s*(provided|expected|currentToken|previousToken|a|b)/)
+  assert.equal(
+    tokenCompareEquals,
+    null,
+    'safeCompare must not use === to compare token contents',
+  )
+})
+
+test('H4 regression guard: length mismatch path also calls timingSafeEqual (decoy)', () => {
+  const src = readFileSync(TOKEN_HOLDER_PATH, 'utf-8')
+  // Both the length-mismatch branch AND the invalid-input early return should
+  // call timingSafeEqual with a dummy to maintain constant time.
+  const dummyCalls = (src.match(/timingSafeEqual\s*\(\s*DUMMY/g) || []).length
+  assert.ok(
+    dummyCalls >= 2,
+    `expected ≥2 timingSafeEqual(DUMMY,…) decoy calls, found ${dummyCalls}`,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Behavioral correctness — isTokenValid returns correct boolean
+// ---------------------------------------------------------------------------
+
+test('H4 isTokenValid: returns false for undefined/null/empty', () => {
+  _resetForTests('correct-token')
+  assert.equal(isTokenValid(undefined), false)
+  assert.equal(isTokenValid(null), false)
+  assert.equal(isTokenValid(''), false)
+})
+
+test('H4 isTokenValid: returns true for correct token', () => {
+  _resetForTests('correct-token')
+  assert.equal(isTokenValid('correct-token'), true)
+})
+
+test('H4 isTokenValid: returns false for wrong token (same length)', () => {
+  _resetForTests('correct-token')
+  assert.equal(isTokenValid('WRONGGG-token'), false) // same length, different content
+})
+
+test('H4 isTokenValid: returns false for wrong token (different length)', () => {
+  _resetForTests('correct-token')
+  assert.equal(isTokenValid('short'), false)
+  assert.equal(isTokenValid('much-longer-than-correct-token'), false)
+})
+
+// ---------------------------------------------------------------------------
+// Light statistical guard — coarse timing comparison (CI-flaky, informational)
+// ---------------------------------------------------------------------------
+
+test('H4 isTokenValid: statistical timing — same-length wrong vs correct close in mean', () => {
+  _resetForTests('correct-token-32-chars-padding-x')
+  const ITER = 5_000
+
+  // Pre-warm V8
+  for (let i = 0; i < 100; i++) {
+    isTokenValid('correct-token-32-chars-padding-x')
+    isTokenValid('WRONGGG-token-32-chars-padding-x')
+  }
+
+  const correctTimes: number[] = []
+  const wrongTimes: number[] = []
+  for (let i = 0; i < ITER; i++) {
+    const t0 = process.hrtime.bigint()
+    isTokenValid('correct-token-32-chars-padding-x')
+    correctTimes.push(Number(process.hrtime.bigint() - t0))
+  }
+  for (let i = 0; i < ITER; i++) {
+    const t0 = process.hrtime.bigint()
+    isTokenValid('WRONGGG-token-32-chars-padding-x')
+    wrongTimes.push(Number(process.hrtime.bigint() - t0))
+  }
+  const mean = (arr: number[]) => arr.reduce((s, v) => s + v, 0) / arr.length
+  const correctMean = mean(correctTimes)
+  const wrongMean = mean(wrongTimes)
+  // CI-tolerant: 5x ratio allowance (timingSafeEqual is constant-time at HW level
+  // but JS overhead noise can cause variance). Strict ratio would be ~1.5x.
+  const ratio = Math.max(correctMean, wrongMean) / Math.min(correctMean, wrongMean)
+  // Informational — do not fail on tight ratio, but document the measurement.
+  // Strict assertion below allows ratio up to 5x (very loose, CI-safe).
+  assert.ok(
+    ratio < 5,
+    `same-length correct vs wrong timing ratio = ${ratio.toFixed(2)} (expected < 5x noise floor)`,
+  )
+})

--- a/packages/server/src/audit/append-only-flag.ts
+++ b/packages/server/src/audit/append-only-flag.ts
@@ -1,0 +1,95 @@
+// CSR #775 P7 H3: chattr/chflags append-only flag 신규
+// Refs: CSR #771 R4 DeepSeek H1 — chattr silent failure → audit log tampering
+// Plan v2: ~/workspace/gijun-ai/prompt_plan.md §P7
+//
+// Purpose: audit DB 파일에 OS append-only flag 적용. tamper detection (hash chain)에
+// 추가하여 prevention layer 제공. production에서 실패 시 boot abort.
+
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import os from 'node:os'
+
+export class AppendOnlyFlagError extends Error {
+  constructor(public reason: string) {
+    super(`audit_append_only_flag_failed: ${reason}`)
+    this.name = 'AppendOnlyFlagError'
+  }
+}
+
+export function isSupported(): boolean {
+  const platform = os.platform()
+  return platform === 'darwin' || platform === 'linux'
+}
+
+/**
+ * Apply OS-level append-only flag to a file.
+ * - macOS: chflags uappnd (user-level, no sudo)
+ * - Linux: chattr +a (requires root or CAP_LINUX_IMMUTABLE)
+ * Throws AppendOnlyFlagError on any failure.
+ */
+export function applyAppendOnlyFlag(dbPath: string): void {
+  if (!existsSync(dbPath)) {
+    throw new AppendOnlyFlagError(`file not found: ${dbPath}`)
+  }
+  const platform = os.platform()
+  if (platform === 'darwin') {
+    try {
+      execFileSync('chflags', ['uappnd', dbPath], { stdio: 'pipe' })
+    } catch (err) {
+      throw new AppendOnlyFlagError(`chflags uappnd failed: ${(err as Error).message}`)
+    }
+  } else if (platform === 'linux') {
+    try {
+      execFileSync('chattr', ['+a', dbPath], { stdio: 'pipe' })
+    } catch (err) {
+      throw new AppendOnlyFlagError(`chattr +a failed: ${(err as Error).message}`)
+    }
+  } else {
+    throw new AppendOnlyFlagError(`unsupported platform: ${platform}`)
+  }
+}
+
+/**
+ * Safe variant — returns success/failure as a result object instead of throwing.
+ * Useful for non-production environments where failure should warn but not abort.
+ */
+export function applyAppendOnlyFlagSafe(dbPath: string): {
+  applied: boolean
+  reason?: string
+} {
+  try {
+    applyAppendOnlyFlag(dbPath)
+    return { applied: true }
+  } catch (err) {
+    if (err instanceof AppendOnlyFlagError) {
+      return { applied: false, reason: err.reason }
+    }
+    return { applied: false, reason: String(err) }
+  }
+}
+
+/**
+ * Apply append-only flag with production fail-closed semantics.
+ * - production: throws AppendOnlyFlagError on failure
+ * - non-production: logs warning and continues
+ */
+export function applyAppendOnlyFlagAtBoot(
+  dbPath: string,
+  opts?: { logger?: (msg: string) => void; isProd?: boolean },
+): void {
+  const isProd =
+    opts?.isProd ?? process.env['NODE_ENV'] === 'production'
+  const log = opts?.logger ?? ((msg: string): void => console.warn(msg))
+  const result = applyAppendOnlyFlagSafe(dbPath)
+  if (result.applied) {
+    return
+  }
+  if (isProd) {
+    throw new AppendOnlyFlagError(
+      `production boot abort — ${result.reason ?? 'unknown'}`,
+    )
+  }
+  log(
+    `[agentguard] append-only flag failed (non-prod, continuing): ${result.reason ?? 'unknown'}`,
+  )
+}

--- a/packages/server/src/auth/cluster-guard.ts
+++ b/packages/server/src/auth/cluster-guard.ts
@@ -1,0 +1,44 @@
+// CSR #775 P4 M6: cluster guard 신규 도입
+// Refs: CSR #771 R3 Claude Web M-R3-3 (코드 correctness bug catch — isMainThread import 누락)
+// Plan v2: ~/workspace/gijun-ai/prompt_plan.md §P4
+//
+// Purpose: single-process invariant 강제. Token holder의 rotateInFlight boolean mutex는
+// cluster mode 또는 worker_threads 환경에서 invariant가 깨짐. Boot 시점에 fail-closed.
+
+import cluster from 'node:cluster'
+import { isMainThread } from 'node:worker_threads'
+
+export function isClusterWorker(): boolean {
+  return cluster.isWorker
+}
+
+export function isWorkerThread(): boolean {
+  return !isMainThread
+}
+
+export function isForkedChild(): boolean {
+  // child_process.fork() spawned process has process.send as a function;
+  // standalone or cluster-primary has undefined.
+  return typeof process.send === 'function'
+}
+
+export class ClusterUnsafeError extends Error {
+  constructor(public reason: string) {
+    super(`cluster_unsafe: ${reason}`)
+    this.name = 'ClusterUnsafeError'
+  }
+}
+
+export function assertSingleInstance(): void {
+  if (isClusterWorker()) {
+    throw new ClusterUnsafeError('worker process detected (cluster.isWorker=true)')
+  }
+  if (isWorkerThread()) {
+    throw new ClusterUnsafeError('worker thread detected (isMainThread=false)')
+  }
+  if (isForkedChild()) {
+    throw new ClusterUnsafeError(
+      'forked child process detected (process.send is function)',
+    )
+  }
+}

--- a/packages/server/src/auth/env-file.ts
+++ b/packages/server/src/auth/env-file.ts
@@ -11,6 +11,7 @@ import {
   writeSync,
 } from 'node:fs'
 import { dirname, resolve as pathResolve } from 'node:path'
+import { validTestMode } from './test-mode.js'
 
 const TOKEN_KEY = 'AGENTGUARD_TOKEN'
 
@@ -24,10 +25,18 @@ export class EnvFileError extends Error {
 export function resolveEnvFilePath(): string {
   const override = process.env['AGENTGUARD_ENV_FILE']
   if (override) {
+    // CSR #775 P2 C1: NODE_ENV alone is bypassable via env injection (DeepSeek R4).
+    // Require BOTH NODE_ENV=test AND a valid AGENTGUARD_TEST_MODE HMAC token.
     if (process.env['NODE_ENV'] !== 'test') {
       throw new EnvFileError(
         'env_file_override_in_non_test',
         'AGENTGUARD_ENV_FILE is only honored when NODE_ENV=test',
+      )
+    }
+    if (!validTestMode(process.env['AGENTGUARD_TEST_MODE'])) {
+      throw new EnvFileError(
+        'env_file_override_missing_valid_hmac',
+        'AGENTGUARD_ENV_FILE requires a valid AGENTGUARD_TEST_MODE HMAC token',
       )
     }
     return pathResolve(override)

--- a/packages/server/src/auth/test-mode.ts
+++ b/packages/server/src/auth/test-mode.ts
@@ -1,0 +1,80 @@
+// CSR #775 P1 C2: AGENTGUARD_TEST_MODE HMAC Key Management
+// Refs: CSR #771 R4 DeepSeek finding — NODE_ENV bypass via AGENTGUARD_ENV_FILE
+// Plan v2: ~/workspace/gijun-ai/prompt_plan.md §P1
+
+import crypto from 'node:crypto'
+
+const HMAC_KEY = process.env['AGENTGUARD_CONFIG_HMAC_KEY']
+const IS_PROD = process.env['NODE_ENV'] === 'production'
+const BOOT_EPOCH = Date.now()
+
+if (!HMAC_KEY && IS_PROD) {
+  throw new Error(
+    'agentguard_config_hmac_key_required_in_production: ' +
+      'AGENTGUARD_CONFIG_HMAC_KEY env var must be set when NODE_ENV=production. ' +
+      'See docs/migration-CSR-775.md for setup.'
+  )
+}
+
+interface TestModePayload {
+  epoch: number
+  ttl: number
+}
+
+export function getBootEpoch(): number {
+  return BOOT_EPOCH
+}
+
+export function generateTestMode(ttlMs: number): string {
+  if (!HMAC_KEY) {
+    throw new Error('agentguard_config_hmac_key_not_set: cannot generate token')
+  }
+  const payload = Buffer.from(
+    JSON.stringify({ epoch: BOOT_EPOCH, ttl: ttlMs } satisfies TestModePayload)
+  ).toString('base64')
+  const signature = crypto
+    .createHmac('sha256', HMAC_KEY)
+    .update(payload)
+    .digest('hex')
+  return `${payload}.${signature}`
+}
+
+export function validTestMode(token: string | undefined): boolean {
+  if (!token || !HMAC_KEY) return false
+  const parts = token.split('.')
+  if (parts.length !== 2) return false
+  const [payload, signature] = parts
+  if (!payload || !signature) return false
+
+  let parsed: TestModePayload
+  try {
+    parsed = JSON.parse(
+      Buffer.from(payload, 'base64').toString('utf-8')
+    ) as TestModePayload
+  } catch {
+    return false
+  }
+
+  if (typeof parsed.epoch !== 'number' || typeof parsed.ttl !== 'number') {
+    return false
+  }
+  if (parsed.epoch !== BOOT_EPOCH) return false // anti-replay
+  if (parsed.ttl < Date.now()) return false // TTL expired
+
+  const expected = crypto
+    .createHmac('sha256', HMAC_KEY)
+    .update(payload)
+    .digest('hex')
+
+  // Length check before timingSafeEqual (avoid RangeError)
+  if (signature.length !== expected.length) return false
+
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(signature, 'utf-8'),
+      Buffer.from(expected, 'utf-8')
+    )
+  } catch {
+    return false
+  }
+}

--- a/packages/server/src/auth/test-mode.ts
+++ b/packages/server/src/auth/test-mode.ts
@@ -7,12 +7,24 @@ import crypto from 'node:crypto'
 const HMAC_KEY = process.env['AGENTGUARD_CONFIG_HMAC_KEY']
 const IS_PROD = process.env['NODE_ENV'] === 'production'
 const BOOT_EPOCH = Date.now()
+const MIN_HMAC_KEY_LENGTH = 32 // 256-bit entropy minimum (32 hex chars or 32 bytes raw)
 
 if (!HMAC_KEY && IS_PROD) {
   throw new Error(
     'agentguard_config_hmac_key_required_in_production: ' +
       'AGENTGUARD_CONFIG_HMAC_KEY env var must be set when NODE_ENV=production. ' +
       'See docs/migration-CSR-775.md for setup.'
+  )
+}
+
+// H-INT-3 (Internal review fix): weak-key brute-force resistance.
+// Reject HMAC_KEY shorter than 32 chars at module load to prevent ~24-bit entropy keys.
+if (HMAC_KEY && HMAC_KEY.length < MIN_HMAC_KEY_LENGTH) {
+  throw new Error(
+    `agentguard_config_hmac_key_too_short: ` +
+      `AGENTGUARD_CONFIG_HMAC_KEY must be at least ${MIN_HMAC_KEY_LENGTH} chars ` +
+      `(256-bit entropy). Got ${HMAC_KEY.length} chars. ` +
+      `Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
   )
 }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2,6 +2,7 @@ import { runMigrations, assertSchemaChain, closeDb } from '@gijun-ai/core'
 import { createApp } from './app.js'
 import { sweepTmpFiles } from './auth/env-file.js'
 import { assertSingleInstance } from './auth/cluster-guard.js'
+import { applyAppendOnlyFlagAtBoot } from './audit/append-only-flag.js'
 
 // CSR #775 P4 M6: fail-closed cluster/worker_threads/forked child detection.
 // Token holder's rotateInFlight boolean mutex is process-local; cluster mode
@@ -32,6 +33,13 @@ runMigrations()
 
 // Verify full migration chain before accepting requests (contract #2).
 assertSchemaChain(['001_initial', '002_original_hash', '003_original_hash_type', '004_cost_budget', '005_policy_eval_index', '006_cost_parse_status', '007_knowledge_status', '008_external_sync'])
+
+// CSR #775 P7 H3: apply OS append-only flag to audit DB file (production fail-closed).
+// Skip when DB path is :memory: (test mode) or unset (cannot resolve default reliably).
+const auditDbPath = process.env['GIJUN_DB_PATH']
+if (auditDbPath && auditDbPath !== ':memory:') {
+  applyAppendOnlyFlagAtBoot(auditDbPath)
+}
 
 process.on('exit', () => closeDb())
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,6 +1,12 @@
 import { runMigrations, assertSchemaChain, closeDb } from '@gijun-ai/core'
 import { createApp } from './app.js'
 import { sweepTmpFiles } from './auth/env-file.js'
+import { assertSingleInstance } from './auth/cluster-guard.js'
+
+// CSR #775 P4 M6: fail-closed cluster/worker_threads/forked child detection.
+// Token holder's rotateInFlight boolean mutex is process-local; cluster mode
+// or worker_threads break the invariant. Refuse to boot in unsafe topology.
+assertSingleInstance()
 
 // fail-closed: token must be set before any request can succeed
 if (!process.env['AGENTGUARD_TOKEN']) {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,4 +1,4 @@
-import { runMigrations, assertSchemaChain, closeDb } from '@gijun-ai/core'
+import { runMigrations, assertSchemaChain, closeDb, currentDbPath } from '@gijun-ai/core'
 import { createApp } from './app.js'
 import { sweepTmpFiles } from './auth/env-file.js'
 import { assertSingleInstance } from './auth/cluster-guard.js'
@@ -35,9 +35,12 @@ runMigrations()
 assertSchemaChain(['001_initial', '002_original_hash', '003_original_hash_type', '004_cost_budget', '005_policy_eval_index', '006_cost_parse_status', '007_knowledge_status', '008_external_sync'])
 
 // CSR #775 P7 H3: apply OS append-only flag to audit DB file (production fail-closed).
-// Skip when DB path is :memory: (test mode) or unset (cannot resolve default reliably).
-const auditDbPath = process.env['GIJUN_DB_PATH']
-if (auditDbPath && auditDbPath !== ':memory:') {
+// H-INT-1 (Internal review fix): use currentDbPath() to cover ALL canonical paths
+// (AGENTGUARD_DB_PATH > GIJUN_DB_PATH > default <cwd>/.agentguard/agentguard.db).
+// Previous logic used only process.env['GIJUN_DB_PATH'] which silently skipped
+// the protection for the canonical AGENTGUARD_DB_PATH and default-path deployments.
+const auditDbPath = currentDbPath()
+if (auditDbPath !== ':memory:') {
   applyAppendOnlyFlagAtBoot(auditDbPath)
 }
 


### PR DESCRIPTION
## Summary

CSR #771 외부 4-AI Tier 1 (security) DA 검증 결과를 통합 적용. 11 fixes 처리.

선행: PR #42 (CSR #758 Settings tab) → 머지 완료 (commit `5507969`).
관련 CSR: #775 (본 PR), #771 (DA verification), #777 (carry-forward hardening), #778 (carry-forward DA infra).

## Fixes 인덱스 (11건)

### CRITICAL 2 (DeepSeek R4 NEW)
- **C1** F5 mitigation (b)+(c) 통합 — `NODE_ENV=test` + `AGENTGUARD_ENV_FILE` 우회 차단 (HMAC token 필수)
- **C2** `AGENTGUARD_CONFIG_HMAC_KEY` 신설 + boot-epoch anti-replay + TTL

### HIGH 3
- **H3** OS append-only flag (chflags/chattr) — production fail-closed
- **H4** `crypto.timingSafeEqual` verification + regression guard (이미 적용된 코드 + AST grep + statistical timing test)
- **H5** X-AgentGuard-CLI header **Option B** — header = path hint, NOT auth (docs only, KISS)

### MEDIUM 3
- **M6** cluster guard 정정 — `isMainThread` import + `process.send` check + Red-Green
- **M7 N/A** — UA-based detection 코드 grep 0건 (R3 r2-reflected mitigation 자체 비판)
- **M8 N/A** — fs.watch / SIGHUP reload mechanism 미구현 → symlink race surface 없음

### LOW 3
- **L9** carry-forward 추적 ID — threat-model §8 + CSR #777/#778
- **L10** threat model "Out-of-scope" 정밀화 — localhost bind-race conditional in-scope
- **L11** CWD allowlist → `AGENTGUARD_TEST_MODE` HMAC (P1 C2에서 통합)

## Breaking Change

`AGENTGUARD_CONFIG_HMAC_KEY` 필수 env var (production NODE_ENV). 자세한 migration은 `docs/migration-CSR-775.md` 참조.

## Test plan

- [x] `pnpm typecheck && pnpm build && pnpm test` — exit 0 (66/66 pass packages/server)
- [x] CRITICAL 2건 Red-Green:
  - C1: NODE_ENV=test + AGENTGUARD_ENV_FILE without HMAC → throws (env-file-integration.test.ts)
  - C2: production + missing AGENTGUARD_CONFIG_HMAC_KEY → boot abort (test-mode.test.ts)
- [x] HIGH 3건 Red-Green:
  - H3: append-only-flag.test.ts (isSupported / non-existent path / safe variant / real file best-effort)
  - H4: timing-attack.test.ts (regression guard + statistical timing)
  - H5: threat-model-CSR-775.md (Option B residual risks)
- [x] MEDIUM 3건:
  - M6: cluster-guard.test.ts (5 tests, standalone passes + export shape)
  - M7: N/A 박제
  - M8: N/A 박제 (threat-model §6.1)
- [x] LOW 3건: docs (threat-model + migration)
- [x] 회귀: 기존 auth.rotate-token.e2e.test.ts 18 tests + db.stats 3 + hitl-flow 등 모두 pass
- [ ] Internal Claude security-engineer 재검토 — 본 PR open 직후 별도 turn에서 진행

## CWE coverage

CWE-352 (CSRF) · CWE-916 (token hash) · CWE-208 (timing) · CWE-345 (data authenticity) · CWE-330 (HMAC key origin) · CWE-367 (TOCTOU) · CWE-732 (incorrect permission) · CWE-362 (race condition) · CWE-664 (resource lifetime)

## Documents

- `docs/threat-model-CSR-775.md` (신규) — attacker classes / trust boundary / crown jewels / per-fix residual risks
- `docs/migration-CSR-775.md` (신규) — AGENTGUARD_CONFIG_HMAC_KEY 도입 가이드 + Vercel/Docker/systemd 등록 방법별 + 롤백 절차
- `CHANGELOG.md` [0.6.0] Post-DA Hardening 블록 추가

## Refs

- 출처 DA: CSR #771 final.txt (4-AI Tier 1 Gemini → ChatGPT → Claude Web → DeepSeek)
- 사용자 결정 박제: CSR #775 본문 + 댓글 #2467 (2단계) + #2468 (3단계)
- DeepSeek R4 NEW CRITICAL 2건 = 본 4-AI sequential DA의 핵심 가치 (`feedback_da_anti_patterns-part13.md` #20 박제)

🤖 Generated with [Claude Code](https://claude.com/claude-code)