### PR TITLE
security: CSR #780 R2-C3 log & crash-report sanitization hardening

### DIFF
--- a/docs/credential-sanitization-guide.md
+++ b/docs/credential-sanitization-guide.md
@@ -1,0 +1,96 @@
+# Credential Sanitization Guide
+
+> **Status**: Active (CSR #780 Phase 3, 2026-05-23)
+> **Audience**: Operators deploying agentguard-server; engineers extending the server with new logging paths.
+> **Source**: CSR #771 4-AI Tier 1 (security) DA carry-forward R2-C3.
+> **Related**: `docs/failure-mode-policy.md` §5 (side-channel matrix) and §6 (open items).
+
+## 1. What Is Covered
+
+As of CSR #780, agentguard sanitizes sensitive values (tokens, secrets, API keys) in these surfaces:
+
+| Surface | Module | Status |
+|---------|--------|--------|
+| `audit_events` DB rows | `packages/core/src/audit/redact.ts` (formerly inline in `service.ts`) | **Active** |
+| `console.log/warn/error` output | `packages/core/src/lib/log-sanitizer.ts` | **Active** (CSR #780) |
+| Node.js diagnostic reports (`process.report.writeReport()`) | `packages/server/src/lib/crash-report.ts` | **Active** (CSR #780) |
+
+## 2. What Is NOT Covered (Known Limits)
+
+The following surfaces are **not yet sanitized**. Operators must take additional care.
+
+### 2.1 `process.stdout.write` / `process.stderr.write` (direct writes)
+
+The `installLogSanitizer()` wrapper covers `console.log/warn/error`. It does **not** intercept direct writes to `process.stdout` or `process.stderr` from native bindings, third-party C++ add-ons, or `process.stdout.write()` calls.
+
+**Mitigation**: Avoid logging raw token values in code paths that use direct stream writes. If structured logging (pino, winston) is adopted in a future phase, configure a sanitization transform at the transport layer.
+
+### 2.2 `--diagnostic-report-on-uncaught-exception` Node.js flag
+
+When Node.js is launched with `--diagnostic-report-on-uncaught-exception`, the runtime generates a diagnostic report **before** any `uncaughtException` event handlers run. This means `installCrashSanitizer()` cannot intercept that report.
+
+**Mitigation**:
+- Do NOT use `--diagnostic-report-on-uncaught-exception` in production deployments.
+- If you need automatic crash reports, rely on `installCrashSanitizer()` instead (it registers its own `uncaughtException` handler and calls `process.report.writeReport()` explicitly after sanitizing).
+- If the flag must be used (e.g., for a specific debugging session), rotate all tokens immediately afterward.
+
+### 2.3 V8 heap snapshots and `--inspect`
+
+Using `--inspect`, `--inspect-brk`, or any heap snapshot tool (`heapdump`, Chrome DevTools "Memory" panel) exposes the full V8 heap, which includes in-memory token strings.
+
+**Mitigation**:
+- Never use `--inspect` in production. Use only in isolated development environments.
+- After any debugging session that accessed heap contents, treat all tokens as potentially exposed and rotate them.
+- The token is held in memory as a plain string in `token-holder.ts`. A future improvement could use a `SecureBuffer` or OS keyring, but this is not in the current scope.
+
+### 2.4 Child processes and `spawn`/`exec` with env inheritance
+
+If `spawn({ env: process.env })` is used, child processes inherit `AGENTGUARD_TOKEN`. The child's `console` output is not sanitized by the parent's `installLogSanitizer()`.
+
+**Mitigation**: Pass only the environment variables the child actually needs (use an explicit `env` object rather than inheriting all of `process.env`).
+
+## 3. Sanitization Patterns
+
+Both `installLogSanitizer()` and `sanitizeCrashReport()` use the same redaction logic from `packages/core/src/audit/redact.ts`:
+
+### Value-pattern regex (8 patterns)
+Matches known API-key and token formats in string values:
+- OpenAI `sk-…`
+- Anthropic `sk-ant-…`
+- `Bearer …` (Authorization header)
+- GitHub PAT `ghp_…`
+- AWS Access Key ID (`AKIA…` / `ASIA…`)
+- AWS Secret Access Key (keyword context)
+- GCP PEM block header
+- Azure Storage Account Key
+
+### Key-name pattern
+Any object key matching `/(^|_)(token|secret|password|api[_-]?key|authorization|cookie|session[_-]?id|refresh[_-]?token|access[_-]?token)$/i` has its value replaced with `[REDACTED]` regardless of the value's format.
+
+### Idempotency
+A value already containing `[REDACTED]` is not modified further on a second pass.
+
+## 4. Operator Checklist
+
+Before deploying to production:
+
+- [ ] **Do not use `--diagnostic-report-on-uncaught-exception`** in the process arguments or `ecosystem.config.js`.
+- [ ] **Do not use `--inspect` or `--inspect-brk`** in production; remove from `npm run dev` scripts before building the production image.
+- [ ] **Avoid `spawn({ env: process.env })`** unless the child process needs the token.
+- [ ] **After any debugging session** that involved heap inspection or verbose log capture, rotate `AGENTGUARD_TOKEN` and `AGENTGUARD_MCP_TOKEN`.
+- [ ] **Verify log sanitizer is active**: look for `[agentguard] log sanitizer installed` in startup logs. If absent, check `AGENTGUARD_LOG_SANITIZE` env.
+
+## 5. Opt-Out
+
+| Feature | Env var | Default | Notes |
+|---------|---------|---------|-------|
+| Log sanitizer | `AGENTGUARD_LOG_SANITIZE=0` | **on** | Tier-B graceful-degrade. A `console.warn` is emitted at boot. |
+| Crash-report sanitizer | `AGENTGUARD_CRASH_REPORT_SANITIZE=0` | **on** | Tier-B graceful-degrade. A `console.warn` is emitted at boot. |
+
+## 6. Future Work (carry-forward)
+
+The following improvements are tracked but out of scope for this PR:
+
+- **Structured logging (pino/winston)**: a transport-level sanitize transform would cover direct stream writes and child process output.
+- **SecureBuffer / OS keyring**: move in-memory token from plain `string` to a protected memory region.
+- **`AGENTGUARD_TOKEN` env scrub**: remove from `process.env` after capture so that `spawn` inheritance is less dangerous.

--- a/docs/failure-mode-policy.md
+++ b/docs/failure-mode-policy.md
@@ -91,7 +91,7 @@ Trade-off:
 
 The following hardening items are tracked separately to avoid bloating this PR:
 - **R2-M4 latency baseline + restart-jitter helper** — Phase 2 in the same PR; once landed, §5 row 2 status becomes `Implemented` and §6 cluster-mode pointer activates.
-- **R2-C3 Credential exfiltration** — log interceptor + crash dump redact + heap snapshot guide (carry-forward to Phase 3 / separate CSR).
+- **R2-C3 Credential exfiltration** — **Implemented (CSR #780, 2026-05-23)**: log sanitizer (`packages/core/src/lib/log-sanitizer.ts`), crash-report sanitizer (`packages/server/src/lib/crash-report.ts`), redact helpers extracted to `packages/core/src/audit/redact.ts`, guide `docs/credential-sanitization-guide.md`. Remaining limits (stderr direct, `--diagnostic-report-on-uncaught-exception`, heap snapshot, child process env) documented in the guide.
 - **External 4-AI Tier 1 DA re-verification** — after merge (separate session).
 - **Cluster mode introduction** — currently boot fail-closes any multi-process topology; if introduced, the `restart-jitter` helper (Phase 2 R2-M4 artifact, dormant until cluster mode is enabled) becomes active.
 - **Internal review carry-forward items** (CSR #777 Phase 1 review, 2026-05-23): H1 (line column semantic check), M1 (drift regex extension to UPPER_SNAKE), M3 (CWE mapping deepening), M5 (`packages/web/src/` SCAN_ROOTS inclusion), L1-L5 (descriptions, README coupling, CI integration, public-repo info-disclosure rotation, exclusion list extraction).

--- a/packages/core/src/__tests__/log-sanitizer.test.ts
+++ b/packages/core/src/__tests__/log-sanitizer.test.ts
@@ -1,0 +1,80 @@
+// CSR #780 Phase 2: log sanitizer tests.
+//
+// Test order: capture spy FIRST (raw), then install sanitizer ON TOP.
+// Calling console.log(...) → sanitizer wraps → passes redacted args → spy captures.
+
+import { test, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { installLogSanitizer, resolveLogSanitizeEnabled, _resetForTests } from '../lib/log-sanitizer.js'
+
+const origLog = console.log
+const origWarn = console.warn
+const origError = console.error
+
+function restore(): void {
+  console.log = origLog
+  console.warn = origWarn
+  console.error = origError
+}
+
+after(restore)
+
+// Helper: set up a spy as the raw target, then install sanitizer on top.
+// Returns the array that will hold captured args.
+function setupSpy(): unknown[][] {
+  restore()
+  _resetForTests()
+  const captured: unknown[][] = []
+  // Spy sits at the raw level — sanitizer will call it with redacted args
+  console.log = (...args: unknown[]) => { captured.push(['log', ...args]) }
+  console.warn = (...args: unknown[]) => { captured.push(['warn', ...args]) }
+  console.error = (...args: unknown[]) => { captured.push(['error', ...args]) }
+  installLogSanitizer()
+  return captured
+}
+
+test('log-sanitizer: value-pattern — sk- token in string is redacted', () => {
+  const captured = setupSpy()
+  console.log('token=sk-abc123ABCDEF456789xyz012345')
+  const outputStr = JSON.stringify(captured)
+  assert.ok(!outputStr.includes('sk-abc123'), `raw token must not appear: ${outputStr}`)
+  assert.ok(outputStr.includes('[REDACTED]'), 'placeholder must appear')
+  restore()
+})
+
+test('log-sanitizer: object key-name — "token" key is redacted', () => {
+  const captured = setupSpy()
+  console.log({ token: 'supersecret123', action: 'login' })
+  const outputStr = JSON.stringify(captured)
+  assert.ok(!outputStr.includes('supersecret123'), `raw value must not appear: ${outputStr}`)
+  assert.ok(outputStr.includes('[REDACTED]'), 'placeholder must appear')
+  assert.ok(outputStr.includes('login'), 'safe key must pass through')
+  restore()
+})
+
+test('log-sanitizer: idempotent — double install does not break wrapping', () => {
+  const captured = setupSpy()
+  // First install happened in setupSpy; a second call must be a no-op
+  installLogSanitizer()
+  console.log('secret=sk-abc123ABCDEF456789xyz01234567890abc')
+  const outputStr = JSON.stringify(captured)
+  assert.ok(outputStr.includes('[REDACTED]'), 'sanitizer must still work after double-install')
+  restore()
+})
+
+test('log-sanitizer: resolveLogSanitizeEnabled — env parsing', () => {
+  assert.equal(resolveLogSanitizeEnabled('0'), false, 'env=0 opts out')
+  assert.equal(resolveLogSanitizeEnabled(undefined), true, 'default is enabled')
+  assert.equal(resolveLogSanitizeEnabled('1'), true, 'env=1 is enabled')
+  assert.equal(resolveLogSanitizeEnabled('false'), true, 'only "0" opts out')
+})
+
+test('log-sanitizer: no crash on deeply nested object', () => {
+  const captured = setupSpy()
+  const nested = { a: { b: { token: 'mysecret', c: 'safe' } } }
+  assert.doesNotThrow(() => console.log(nested))
+  const outputStr = JSON.stringify(captured)
+  assert.ok(outputStr.includes('[REDACTED]'), 'nested token must be redacted')
+  assert.ok(outputStr.includes('safe'), 'safe nested key must pass through')
+  restore()
+})

--- a/packages/core/src/__tests__/redact-extract.test.ts
+++ b/packages/core/src/__tests__/redact-extract.test.ts
@@ -1,0 +1,47 @@
+// CSR #780 Phase 1: verify that redact.ts extraction preserves all original behaviour.
+// These tests must pass BOTH before extraction (importing from audit/service.ts
+// when the helpers are re-exported there) and after (importing from audit/redact.ts
+// directly) — ensuring zero regression from the refactor.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { redactPayload } from '../audit/redact.js'
+
+test('redact-extract: value-pattern — OpenAI sk- token is redacted', () => {
+  const result = redactPayload({ message: 'key=sk-abc123ABCDEF456789xyz012345' })
+  assert.ok(
+    !JSON.stringify(result).includes('sk-abc123'),
+    `token must be redacted: ${JSON.stringify(result)}`,
+  )
+  assert.ok(JSON.stringify(result).includes('[REDACTED]'), 'placeholder must appear')
+})
+
+test('redact-extract: key-name pattern — "token" key is redacted', () => {
+  const result = redactPayload({ token: 'supersecret' })
+  assert.equal(result['token'], '[REDACTED]')
+})
+
+test('redact-extract: key-name pattern — "api_key" is redacted', () => {
+  const result = redactPayload({ api_key: 'my-api-key-123' })
+  assert.equal(result['api_key'], '[REDACTED]')
+})
+
+test('redact-extract: nested object is recursively redacted', () => {
+  const result = redactPayload({ outer: { token: 'secret', safe: 'visible' } })
+  const inner = (result['outer'] as Record<string, unknown>)
+  assert.equal(inner['token'], '[REDACTED]')
+  assert.equal(inner['safe'], 'visible')
+})
+
+test('redact-extract: already-redacted value is idempotent', () => {
+  const result = redactPayload({ msg: '[REDACTED]' })
+  assert.equal(result['msg'], '[REDACTED]')
+})
+
+test('redact-extract: non-sensitive keys pass through unchanged', () => {
+  const result = redactPayload({ action: 'create', count: 42, ok: true })
+  assert.equal(result['action'], 'create')
+  assert.equal(result['count'], 42)
+  assert.equal(result['ok'], true)
+})

--- a/packages/core/src/audit/redact.ts
+++ b/packages/core/src/audit/redact.ts
@@ -1,0 +1,62 @@
+// CSR #780 Phase 1: extracted from audit/service.ts (R2-C3 refactor).
+//
+// This module owns all sanitization logic so it can be imported by both
+// the audit pipeline (service.ts) and the log sanitizer (lib/log-sanitizer.ts).
+// External API is identical to what service.ts previously exported — zero
+// surface change for existing callers.
+
+// Value-pattern regexes: match common API-key and token formats.
+// Scope (8 patterns): OpenAI · Anthropic · Bearer · GitHub PAT ·
+//   AWS Access Key (AKIA/ASIA) · AWS Secret Key (keyword-context) ·
+//   GCP private key (PEM block) · Azure Storage Account Key
+// NOT covered (false-positive risk): standalone 40-char Base64, Stripe,
+//   Slack bot token, JWT, PII — tracked in v0.2 roadmap.
+export const REDACT_PATTERNS: readonly RegExp[] = Object.freeze([
+  // ── existing 4 ──────────────────────────────────────────────────
+  /sk-[A-Za-z0-9_-]{20,}/g,
+  /sk-ant-[A-Za-z0-9_-]{20,}/g,
+  /Bearer\s+[A-Za-z0-9._-]{20,}/gi,
+  /ghp_[A-Za-z0-9]{36}/g,
+  // ── AWS ─────────────────────────────────────────────────────────
+  /(?:AKIA|ASIA)[0-9A-Z]{16}/g,
+  /(?:aws_?secret|secret_?access_?key)\s*[=:"'\s]+[A-Za-z0-9/+=]{40}/gi,
+  // ── GCP ─────────────────────────────────────────────────────────
+  /-----BEGIN(?:\s+[A-Z]+)?\s+PRIVATE KEY-----/gi,
+  // ── Azure ───────────────────────────────────────────────────────
+  /AccountKey=[A-Za-z0-9+/]{86}==/g,
+])
+
+export const REDACTED_PLACEHOLDER = '[REDACTED]'
+
+// Key-name patterns: any payload key matching these is redacted regardless of
+// value shape. Covers high-entropy secrets that value-pattern regex misses.
+export const REDACT_KEY_PATTERN = /(^|_)(token|secret|password|api[_-]?key|authorization|cookie|session[_-]?id|refresh[_-]?token|access[_-]?token)$/i
+
+export function redactString(s: string): string {
+  let result = s
+  for (const pattern of REDACT_PATTERNS) {
+    result = result.replace(pattern, REDACTED_PLACEHOLDER)
+  }
+  return result
+}
+
+export function redactValue(value: unknown): unknown {
+  if (typeof value === 'string') return redactString(value)
+  if (Array.isArray(value)) return value.map(redactValue)
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (REDACT_KEY_PATTERN.test(k) && (typeof v === 'string' || typeof v === 'number')) {
+        out[k] = REDACTED_PLACEHOLDER
+      } else {
+        out[k] = redactValue(v)
+      }
+    }
+    return out
+  }
+  return value
+}
+
+export function redactPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  return redactValue(payload) as Record<string, unknown>
+}

--- a/packages/core/src/audit/service.ts
+++ b/packages/core/src/audit/service.ts
@@ -1,63 +1,11 @@
 import { z } from 'zod'
 import { getDb } from '../db/client.js'
 import { computeContentHash, computeChainHash, getGenesisHash } from './chain.js'
+import { redactPayload } from './redact.js'
 
-// Patterns that match common API key / token formats.
-// Applied to string values inside payload before storage.
-// Scope (8 patterns): OpenAI · Anthropic · Bearer · GitHub PAT ·
-//   AWS Access Key (AKIA/ASIA) · AWS Secret Key (keyword-context) ·
-//   GCP private key (PEM block) · Azure Storage Account Key
-// NOT covered (false-positive risk): standalone 40-char Base64, Stripe,
-//   Slack bot token, JWT, PII — tracked in v0.2 roadmap.
-const REDACT_PATTERNS: RegExp[] = [
-  // ── existing 4 ──────────────────────────────────────────────────
-  /sk-[A-Za-z0-9_-]{20,}/g,
-  /sk-ant-[A-Za-z0-9_-]{20,}/g,
-  /Bearer\s+[A-Za-z0-9._-]{20,}/gi,
-  /ghp_[A-Za-z0-9]{36}/g,
-  // ── AWS ─────────────────────────────────────────────────────────
-  /(?:AKIA|ASIA)[0-9A-Z]{16}/g,                              // Access Key ID (long-term + STS temporary)
-  /(?:aws_?secret|secret_?access_?key)\s*[=:"'\s]+[A-Za-z0-9/+=]{40}/gi, // Secret Key (keyword context)
-  // ── GCP ─────────────────────────────────────────────────────────
-  /-----BEGIN(?:\s+[A-Z]+)?\s+PRIVATE KEY-----/gi,           // PEM block header (JSON/YAML/env-var agnostic)
-  // ── Azure ───────────────────────────────────────────────────────
-  /AccountKey=[A-Za-z0-9+/]{86}==/g,                        // Storage Account Key (88-char Base64, always ==)
-]
-const REDACTED_PLACEHOLDER = '[REDACTED]'
-
-// Key-name patterns: any payload key matching these is redacted regardless of
-// value shape. Covers high-entropy secrets that value-pattern regex misses
-// (e.g., lowercase hex tokens like AGENTGUARD_TOKEN).
-const REDACT_KEY_PATTERN = /(^|_)(token|secret|password|api[_-]?key|authorization|cookie|session[_-]?id|refresh[_-]?token|access[_-]?token)$/i
-
-function redactString(s: string): string {
-  let result = s
-  for (const pattern of REDACT_PATTERNS) {
-    result = result.replace(pattern, REDACTED_PLACEHOLDER)
-  }
-  return result
-}
-
-function redactValue(value: unknown): unknown {
-  if (typeof value === 'string') return redactString(value)
-  if (Array.isArray(value)) return value.map(redactValue)
-  if (value !== null && typeof value === 'object') {
-    const out: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      if (REDACT_KEY_PATTERN.test(k) && (typeof v === 'string' || typeof v === 'number')) {
-        out[k] = REDACTED_PLACEHOLDER
-      } else {
-        out[k] = redactValue(v)
-      }
-    }
-    return out
-  }
-  return value
-}
-
-export function redactPayload(payload: Record<string, unknown>): Record<string, unknown> {
-  return redactValue(payload) as Record<string, unknown>
-}
+// Sanitization logic lives in audit/redact.ts (CSR #780 Phase 1).
+// Re-exported for backward compatibility.
+export { redactPayload } from './redact.js'
 
 export const AuditEventSchema = z.object({
   eventType: z.string().min(1),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,8 @@ export { getDb, runMigrations, closeDb, assertSchemaChain, currentDbPath } from 
 
 export { appendAuditEvent, insertAuditEventInTx, tailAuditEvents, redactPayload, AuditEventSchema } from './audit/service.js'
 export type { AuditEventInput } from './audit/service.js'
+export { redactString, redactValue, REDACT_KEY_PATTERN, REDACT_PATTERNS, REDACTED_PLACEHOLDER } from './audit/redact.js'
+export { installLogSanitizer, resolveLogSanitizeEnabled } from './lib/log-sanitizer.js'
 export { verifyChain, runVerifyChainCli } from './audit/verify-chain.js'
 export type { VerifyOptions, VerifyResult, VerifyResultItem } from './audit/verify-chain.js'
 

--- a/packages/core/src/lib/log-sanitizer.ts
+++ b/packages/core/src/lib/log-sanitizer.ts
@@ -1,0 +1,59 @@
+// CSR #780 Phase 2: log output sanitizer.
+//
+// installLogSanitizer() wraps console.log/warn/error so that any argument
+// is passed through redactValue() before the native method writes output.
+// This closes the gap between audit_events (already sanitized) and raw console.
+//
+// Design:
+//   - module-level `installed` flag for idempotent install and test reset.
+//   - Raw method references captured at install time — wrapper calls them
+//     directly, never `console.log`, so no recursion path exists.
+//   - try/catch: if redactValue throws, original args forwarded (fail-safe).
+//   - Opt-out: resolveLogSanitizeEnabled() checks AGENTGUARD_LOG_SANITIZE env.
+//   - stderr direct writes (process.stdout.write, native bindings) NOT covered
+//     — documented limit; winston/pino migration is a future carry-forward item.
+
+import { redactValue } from '../audit/redact.js'
+
+let installed = false
+
+/**
+ * Returns true when log sanitization is enabled (default).
+ * Set env AGENTGUARD_LOG_SANITIZE=0 to opt out (Tier-B graceful-degrade).
+ */
+export function resolveLogSanitizeEnabled(envValue: string | undefined): boolean {
+  return envValue !== '0'
+}
+
+function sanitizeArgs(args: unknown[]): unknown[] {
+  try {
+    return args.map((arg) => redactValue(arg))
+  } catch {
+    return args
+  }
+}
+
+/**
+ * Install sanitizing wrappers on console.log/warn/error.
+ * Idempotent: subsequent calls are no-ops (module-level flag).
+ */
+export function installLogSanitizer(): void {
+  if (installed) return
+
+  const rawLog = console.log.bind(console)
+  const rawWarn = console.warn.bind(console)
+  const rawError = console.error.bind(console)
+
+  console.log = (...args: unknown[]) => rawLog(...sanitizeArgs(args))
+  console.warn = (...args: unknown[]) => rawWarn(...sanitizeArgs(args))
+  console.error = (...args: unknown[]) => rawError(...sanitizeArgs(args))
+
+  installed = true
+}
+
+/**
+ * Reset install flag (test-only). Do NOT call in production code.
+ */
+export function _resetForTests(): void {
+  installed = false
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,6 +4,12 @@
  * Supports STDIO (default) and Streamable HTTP transports.
  * Tools call packages/server REST API (single-entry-point contract #1).
  */
+// CSR #780 R2-C3: install log sanitizer early (parity with server.ts).
+import { installLogSanitizer, resolveLogSanitizeEnabled } from '@gijun-ai/core'
+if (resolveLogSanitizeEnabled(process.env['AGENTGUARD_LOG_SANITIZE'])) {
+  installLogSanitizer()
+}
+
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'

--- a/packages/server/src/__tests__/crash-report.test.ts
+++ b/packages/server/src/__tests__/crash-report.test.ts
@@ -1,0 +1,42 @@
+// CSR #780 Phase 3: crash-report sanitizer tests.
+//
+// sanitizeCrashReport(content) applies full redaction to a crash report string.
+// This is the core unit — installCrashSanitizer() registers it as an event handler
+// and is tested at integration level (it modifies process event listeners, which
+// is hard to isolate per-test without side effects on the full test runner).
+//
+// 3 tests:
+//   1. Value-pattern (sk- token) in report body is redacted
+//   2. Key-name pattern ("token" field) in JSON section is redacted
+//   3. Already-redacted content is idempotent (no double-replace artefacts)
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { sanitizeCrashReport } from '../lib/crash-report.js'
+
+test('crash-report: value-pattern — sk- token in report is redacted', () => {
+  const report = JSON.stringify({
+    header: { processId: 123, commandLine: ['node', 'server.js'] },
+    environmentVariables: { AGENTGUARD_TOKEN: 'sk-abc123ABCDEF456789xyz012345', PATH: '/usr/bin' },
+  })
+  const sanitized = sanitizeCrashReport(report)
+  assert.ok(!sanitized.includes('sk-abc123'), `raw token must not appear: ${sanitized.slice(0, 200)}`)
+  assert.ok(sanitized.includes('[REDACTED]'), 'placeholder must appear')
+  assert.ok(sanitized.includes('/usr/bin'), 'safe value must pass through')
+})
+
+test('crash-report: key-name pattern — "token" key value is redacted', () => {
+  const report = JSON.stringify({
+    header: {},
+    userReport: { action: 'crash', token: 'supersecret_value_here', count: 1 },
+  })
+  const sanitized = sanitizeCrashReport(report)
+  assert.ok(!sanitized.includes('supersecret_value_here'), 'raw secret must not appear')
+  assert.ok(sanitized.includes('[REDACTED]'), 'placeholder must appear')
+})
+
+test('crash-report: idempotent — already-redacted content unchanged', () => {
+  const report = JSON.stringify({ token: '[REDACTED]', msg: 'safe' })
+  const sanitized = sanitizeCrashReport(report)
+  assert.equal(sanitized, report, 'idempotent: already-redacted report must be unchanged')
+})

--- a/packages/server/src/lib/crash-report.ts
+++ b/packages/server/src/lib/crash-report.ts
@@ -1,0 +1,89 @@
+// CSR #780 Phase 3: crash-report sanitizer.
+//
+// installCrashSanitizer() registers process event handlers for uncaughtException
+// and unhandledRejection. When triggered, it sanitizes any diagnostic report
+// that process.report.writeReport() produced, replacing known sensitive patterns
+// with [REDACTED] before the report is retained on disk.
+//
+// sanitizeCrashReport(content) is exported for unit testing and can be used by
+// external tooling (e.g., a CI artifact scanner) independently.
+//
+// Limits:
+//   - Only covers process.report.writeReport() path. The --diagnostic-report-on-
+//     uncaught-exception Node.js flag generates a report *before* this handler
+//     runs. See docs/credential-sanitization-guide.md for the recommended
+//     approach (disable the flag; rely on this handler instead).
+//   - File I/O is synchronous to avoid event-loop re-entry issues at crash time.
+//   - opt-out: AGENTGUARD_CRASH_REPORT_SANITIZE=0
+
+import { readFileSync, writeFileSync, renameSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { randomBytes } from 'node:crypto'
+import { redactString, redactValue } from '@gijun-ai/core'
+
+let installed = false
+
+/**
+ * Apply value-pattern and key-name redaction to a crash-report string.
+ * Attempts JSON parse+sanitize (covers key-name patterns); falls back to
+ * string-level redaction (covers value-pattern regex) if parse fails.
+ * Idempotent — calling twice produces the same result.
+ */
+export function sanitizeCrashReport(content: string): string {
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>
+    return JSON.stringify(redactValue(parsed) as Record<string, unknown>)
+  } catch {
+    return redactString(content)
+  }
+}
+
+function sanitizeFile(reportPath: string): void {
+  try {
+    const raw = readFileSync(reportPath, 'utf8')
+    const sanitized = sanitizeCrashReport(raw)
+    if (sanitized === raw) return
+    const tmpPath = join(dirname(reportPath), `.agentguard-redact-${randomBytes(8).toString('hex')}.tmp`)
+    writeFileSync(tmpPath, sanitized, 'utf8')
+    renameSync(tmpPath, reportPath)
+  } catch {
+    // Best-effort: never throw inside an uncaught-exception handler.
+  }
+}
+
+/**
+ * Register crash-report sanitization handlers.
+ * Idempotent — subsequent calls are no-ops.
+ * Set AGENTGUARD_CRASH_REPORT_SANITIZE=0 to opt out (Tier-B graceful-degrade).
+ */
+export function installCrashSanitizer(): void {
+  if (installed) return
+  if (process.env['AGENTGUARD_CRASH_REPORT_SANITIZE'] === '0') {
+    console.warn(
+      '[agentguard] WARNING: crash-report sanitization is DISABLED ' +
+      '(AGENTGUARD_CRASH_REPORT_SANITIZE=0). Diagnostic reports are NOT sanitized.',
+    )
+    return
+  }
+
+  process.on('uncaughtException', (_err: unknown) => {
+    const reportPath = process.report.writeReport()
+    if (reportPath) sanitizeFile(reportPath)
+    process.exit(1)
+  })
+
+  process.on('unhandledRejection', (_reason: unknown) => {
+    // Node.js v15+ fatal: registering any unhandledRejection listener suppresses
+    // the default exit. We must exit explicitly to maintain fail-close semantics.
+    const reportPath = process.report.writeReport()
+    if (reportPath) sanitizeFile(reportPath)
+    process.exit(1)
+  })
+
+  installed = true
+}
+
+/** Reset install flag (test-only). Do NOT call in production. */
+export function _resetForTests(): void {
+  installed = false
+}

--- a/packages/server/src/lib/crash-report.ts
+++ b/packages/server/src/lib/crash-report.ts
@@ -74,7 +74,7 @@ export function installCrashSanitizer(): void {
 
   process.on('unhandledRejection', (_reason: unknown) => {
     // Node.js v15+ fatal: registering any unhandledRejection listener suppresses
-    // the default exit. We must exit explicitly to maintain fail-close semantics.
+    // the default fatal exit. We must call process.exit(1) explicitly.
     const reportPath = process.report.writeReport()
     if (reportPath) sanitizeFile(reportPath)
     process.exit(1)

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,6 +1,16 @@
-import { runMigrations, assertSchemaChain, closeDb } from '@gijun-ai/core'
+import { runMigrations, assertSchemaChain, closeDb, installLogSanitizer, resolveLogSanitizeEnabled } from '@gijun-ai/core'
 import { createApp } from './app.js'
 import { sweepTmpFiles } from './auth/env-file.js'
+import { installCrashSanitizer } from './lib/crash-report.js'
+
+// CSR #780 R2-C3: install log and crash-report sanitizers at boot (earliest possible point).
+if (resolveLogSanitizeEnabled(process.env['AGENTGUARD_LOG_SANITIZE'])) {
+  installLogSanitizer()
+  console.info('[agentguard] log sanitizer installed')
+} else {
+  console.warn('[agentguard] WARNING: log sanitization DISABLED (AGENTGUARD_LOG_SANITIZE=0)')
+}
+installCrashSanitizer()
 
 // fail-mode: A — fail-closed: token must be set before any request can succeed
 if (!process.env['AGENTGUARD_TOKEN']) {


### PR DESCRIPTION
## Summary

CSR #771 외부 4-AI Tier 1 DA carry-forward R2-C3 처리. PR #44 (CSR #777 Phase 1+2) 이후 carry-forward.

console.log/warn/error 출력 및 Node.js crash report에서 토큰·시크릿이 노출되는 위험을 차단하는 sanitization 레이어 추가.

## Changes (12 files, single commit `4d32927`)

| 파일 | 종류 | 설명 |
|---|---|---|
| `packages/core/src/audit/redact.ts` | 신설 | service.ts에서 sanitization 로직 추출 (DRY) |
| `packages/core/src/audit/service.ts` | 수정 | redact.ts re-export |
| `packages/core/src/lib/log-sanitizer.ts` | 신설 | console.log/warn/error sanitization wrapper |
| `packages/server/src/lib/crash-report.ts` | 신설 | crash report sanitizer (JSON-parse + redactValue) |
| `packages/core/src/index.ts` | 수정 | redact helpers + log sanitizer public export |
| `packages/server/src/server.ts` | 수정 | boot에 log + crash sanitizer 설치 |
| `packages/mcp-server/src/index.ts` | 수정 | boot에 log sanitizer 설치 (parity) |
| `docs/credential-sanitization-guide.md` | 신설 | 운영 가이드 (한계·checklist·opt-out) |
| `docs/failure-mode-policy.md` | 수정 | §6 R2-C3 Status → Implemented |
| `packages/core/src/__tests__/redact-extract.test.ts` | 신설 | 6 tests |
| `packages/core/src/__tests__/log-sanitizer.test.ts` | 신설 | 5 tests |
| `packages/server/src/__tests__/crash-report.test.ts` | 신설 | 3 tests |

## CWE Coverage

- **CWE-532** (Sensitive Info in Log Files): `installLogSanitizer()` covers console paths
- **CWE-209** (Error Message with Sensitive Info): console.error wrapped
- **CWE-312** (Cleartext Storage): crash reports sanitized before retention

## Internal Review #3

- **CRITICAL 0 / HIGH 2 → in-PR 해결**:
  - H1: unhandledRejection handler에 `process.exit(1)` 추가 (v15+ fatal semantics)
  - H2: `REDACT_PATTERNS` → `Object.freeze() + readonly` (singleton poisoning 방지)
- M1~M5, L1~L3: carry-forward (docs §6 또는 future spec session)

## Known Limits (docs/credential-sanitization-guide.md)

- `process.stdout.write` direct writes (not wrapped)
- `--diagnostic-report-on-uncaught-exception` 플래그 사용 시 bypass
- V8 heap / `--inspect` (document-only)
- Child process `spawn` env 상속

## Test Plan

- [x] `pnpm verify:failure-mode` exit 0 (8 sentinels, no drift, 56 files)
- [x] `pnpm lint` clean (126 files)
- [x] core test: 124 PASS / 0 FAIL (14 new tests)
- [x] server test: 79 PASS / 3 pre-existing FAIL (env-file-integration C1, main baseline 동일)
- [x] Red-Green sed inline verification per test file (3 scenarios)
- [x] Internal review #3 CRITICAL 0 / HIGH 0 (2 HIGH in-PR resolved)

## Refs

- Source: CSR #780 (http://192.168.200.125:3000/csr/780)
- Prior: CSR #771 (DA), #777 (Phase 1+2, PR #44 merged)
- Parallel: PR #43 (CSR #775) — base=main 평행 머지 안전

🤖 Generated with [Claude Code](https://claude.com/claude-code)