### PR TITLE
test: CSR #761 Phase 1 — Knowledge HITL + Audit integrity E2E

### DIFF
--- a/packages/core/src/knowledge/retriever.ts
+++ b/packages/core/src/knowledge/retriever.ts
@@ -218,7 +218,9 @@ function transitionStatus(
     ).run(toStatus, reason ?? null, isActive, id, fromStatus)
 
     if ((affected.changes as number) !== 1) {
-      db.exec('ROLLBACK')
+      // Outer catch handles ROLLBACK — avoid double-rollback which raises a
+      // "cannot rollback - no transaction is active" SQLite error that masks
+      // the CodedError and surfaces as HTTP 500.
       throw new CodedError(
         ErrorCode.INVALID_STATE,
         `Knowledge item ${id} has status '${row.status ?? 'null'}', expected '${fromStatus}'`

--- a/packages/server/src/__tests__/rest-audit-integrity.e2e.test.ts
+++ b/packages/server/src/__tests__/rest-audit-integrity.e2e.test.ts
@@ -1,0 +1,155 @@
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { Server } from 'node:http'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+process.env['GIJUN_DB_PATH'] = ':memory:'
+process.env['GIJUN_MIGRATIONS_PATH'] = resolve(__dirname, '../../../../migrations')
+process.env['AGENTGUARD_TOKEN'] = 'test-token-audit-integrity'
+
+const { createApp } = await import('../app.js')
+const core = await import('@gijun-ai/core')
+
+const TOKEN = 'test-token-audit-integrity'
+let server: Server
+let baseUrl: string
+
+function authHeaders(): Record<string, string> {
+  return { 'Content-Type': 'application/json', 'X-AgentGuard-Token': TOKEN }
+}
+
+async function appendEvent(label: string, payload: Record<string, unknown> = {}): Promise<number> {
+  const res = await fetch(`${baseUrl}/audit`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({
+      eventType: 'e2e.audit-integrity',
+      actor: 'system',
+      action: label,
+      payload,
+    }),
+  })
+  assert.equal(res.status, 201, `append '${label}' must return 201`)
+  const body = (await res.json()) as { id: number }
+  return body.id
+}
+
+before(async () => {
+  core.runMigrations()
+  const app = createApp()
+  await new Promise<void>((resolvePromise) => {
+    server = app.listen(0, '127.0.0.1', () => resolvePromise())
+  })
+  const addr = server.address()
+  if (typeof addr !== 'object' || addr === null) throw new Error('unexpected address')
+  baseUrl = `http://127.0.0.1:${addr.port}`
+})
+
+after(async () => {
+  await new Promise<void>((resolvePromise) => {
+    server.close(() => resolvePromise())
+  })
+  core.closeDb()
+  delete process.env['GIJUN_DB_PATH']
+  delete process.env['GIJUN_MIGRATIONS_PATH']
+  delete process.env['AGENTGUARD_TOKEN']
+})
+
+test('E2E audit integrity: new events are stored with original_hash_type=redaction_pre', async () => {
+  const id = await appendEvent('original-hash-type test')
+
+  type Row = { original_hash_type: string; original_hash: string | null }
+  const row = core.getDb()
+    .prepare('SELECT original_hash_type, original_hash FROM audit_events WHERE id = ?')
+    .get(id) as Row | undefined
+
+  assert.ok(row, `audit row ${id} must exist`)
+  assert.equal(
+    row.original_hash_type,
+    'redaction_pre',
+    'new appends must mark original_hash_type=redaction_pre (post-migration-002)',
+  )
+  assert.ok(row.original_hash, 'original_hash must be populated for redaction_pre rows')
+})
+
+test('E2E audit integrity: redaction masks sensitive payload while keeping chain valid', async () => {
+  // Append an event carrying both a sensitive key name AND a token-shaped value.
+  // redactPayload should replace both with [REDACTED]. Because chain_hash is
+  // derived from original_hash (unredacted), the chain stays valid afterward.
+  const secret = 'sk-' + 'A'.repeat(40)
+  const id = await appendEvent('redaction test', {
+    token: secret,
+    note: 'plaintext note remains',
+  })
+
+  type Row = { payload: string }
+  const row = core.getDb()
+    .prepare('SELECT payload FROM audit_events WHERE id = ?')
+    .get(id) as Row | undefined
+  assert.ok(row, `audit row ${id} must exist`)
+  const stored = JSON.parse(row.payload) as { token: string; note: string }
+  assert.equal(stored.token, '[REDACTED]', 'sensitive key must be redacted in stored payload')
+  assert.equal(stored.note, 'plaintext note remains', 'non-sensitive fields must be preserved')
+  assert.ok(
+    !row.payload.includes(secret),
+    'raw sk-token must not appear in stored payload',
+  )
+
+  // Chain must still verify clean after redaction.
+  const checkRes = await fetch(`${baseUrl}/audit/integrity-check`, { headers: authHeaders() })
+  assert.equal(checkRes.status, 200, 'integrity-check must return 200 when chain is valid')
+  const result = (await checkRes.json()) as { valid: boolean; broken: unknown[] }
+  assert.equal(result.valid, true, 'chain must remain valid after redaction')
+  assert.deepEqual(result.broken, [], 'no broken links expected after redaction')
+})
+
+test('E2E audit integrity: tampering with prev_hash flips integrity-check to 409 valid=false', async () => {
+  // Append three events to build a multi-row chain segment for this test.
+  const id1 = await appendEvent('tamper baseline 1')
+  const id2 = await appendEvent('tamper baseline 2')
+  const id3 = await appendEvent('tamper baseline 3')
+  assert.ok(id3 > id2 && id2 > id1, 'audit ids must be monotonically increasing')
+
+  // Capture the original prev_hash of the middle row so we can restore the
+  // chain at the end of this test (so subsequent tests, if any are added,
+  // start from a clean chain). The :memory: DB is also fresh per file, but
+  // the cleanup discipline keeps the test self-contained.
+  type HashRow = { prev_hash: string }
+  const originalPrevHash = (
+    core.getDb()
+      .prepare('SELECT prev_hash FROM audit_events WHERE id = ?')
+      .get(id2) as HashRow
+  ).prev_hash
+
+  // Tamper: replace the middle row's prev_hash with a clearly invalid value.
+  const tampered = 'f'.repeat(64)
+  core.getDb()
+    .prepare('UPDATE audit_events SET prev_hash = ? WHERE id = ?')
+    .run(tampered, id2)
+
+  const checkRes = await fetch(`${baseUrl}/audit/integrity-check`, { headers: authHeaders() })
+  assert.equal(
+    checkRes.status,
+    409,
+    'integrity-check must return 409 when the chain is broken',
+  )
+  const result = (await checkRes.json()) as {
+    valid: boolean
+    broken: Array<{ kind: string; id?: number }>
+  }
+  assert.equal(result.valid, false, 'tampered chain must report valid=false')
+  assert.ok(
+    result.broken.some((b) => b.kind === 'linkage' && b.id === id2),
+    `broken array must include linkage failure for id=${id2}, got ${JSON.stringify(result.broken)}`,
+  )
+
+  // Restore the chain so this test does not corrupt state for later tests.
+  core.getDb()
+    .prepare('UPDATE audit_events SET prev_hash = ? WHERE id = ?')
+    .run(originalPrevHash, id2)
+  const restoreRes = await fetch(`${baseUrl}/audit/integrity-check`, { headers: authHeaders() })
+  assert.equal(restoreRes.status, 200, 'chain must be valid again after prev_hash restore')
+})

--- a/packages/server/src/__tests__/rest-knowledge-flow.e2e.test.ts
+++ b/packages/server/src/__tests__/rest-knowledge-flow.e2e.test.ts
@@ -1,0 +1,318 @@
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { Server } from 'node:http'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+process.env['GIJUN_DB_PATH'] = ':memory:'
+process.env['GIJUN_MIGRATIONS_PATH'] = resolve(__dirname, '../../../../migrations')
+process.env['AGENTGUARD_TOKEN'] = 'test-token-knowledge'
+
+const { createApp } = await import('../app.js')
+const core = await import('@gijun-ai/core')
+
+const TOKEN = 'test-token-knowledge'
+let server: Server
+let baseUrl: string
+
+function authHeaders(): Record<string, string> {
+  return { 'Content-Type': 'application/json', 'X-AgentGuard-Token': TOKEN }
+}
+
+function makeCandidate(title: string): number {
+  return core.createDaCandidate({
+    title,
+    content: `content for ${title}`,
+    reasoning: `reasoning for ${title}`,
+    targetLayer: 'project',
+    project: 'e2e-knowledge',
+  })
+}
+
+type KnowledgeRow = {
+  id: number
+  status: string | null
+  is_active: number
+  supersedes_id: number | null
+}
+
+function selectKnowledge(id: number): KnowledgeRow {
+  const row = core.getDb()
+    .prepare('SELECT id, status, is_active, supersedes_id FROM knowledge_items WHERE id = ?')
+    .get(id) as KnowledgeRow | undefined
+  if (!row) throw new Error(`knowledge ${id} not found`)
+  return row
+}
+
+type AuditTailRow = {
+  id: number
+  event_type: string
+  resource_id: string | null
+  payload: string
+}
+
+async function findAuditEvent(
+  eventType: string,
+  resourceId: number,
+): Promise<AuditTailRow | undefined> {
+  const res = await fetch(`${baseUrl}/audit?n=200`, { headers: authHeaders() })
+  assert.equal(res.status, 200, 'audit tail must return 200')
+  const events = (await res.json()) as AuditTailRow[]
+  return events.find(
+    (e) => e.event_type === eventType && e.resource_id === String(resourceId),
+  )
+}
+
+before(async () => {
+  core.runMigrations()
+  const app = createApp()
+  await new Promise<void>((resolvePromise) => {
+    server = app.listen(0, '127.0.0.1', () => resolvePromise())
+  })
+  const addr = server.address()
+  if (typeof addr !== 'object' || addr === null) throw new Error('unexpected address')
+  baseUrl = `http://127.0.0.1:${addr.port}`
+})
+
+after(async () => {
+  await new Promise<void>((resolvePromise) => {
+    server.close(() => resolvePromise())
+  })
+  core.closeDb()
+  delete process.env['GIJUN_DB_PATH']
+  delete process.env['GIJUN_MIGRATIONS_PATH']
+  delete process.env['AGENTGUARD_TOKEN']
+})
+
+// =============================================================================
+// Group A — Happy path 5 transitions
+// =============================================================================
+
+test('E2E knowledge: POST /knowledge/:id/nominate transitions draft → candidate (200)', async () => {
+  const id = makeCandidate('A-nominate')
+  const res = await fetch(`${baseUrl}/knowledge/${id}/nominate`, {
+    method: 'POST', headers: authHeaders(),
+  })
+  assert.equal(res.status, 200, 'nominate must return 200')
+  assert.equal(selectKnowledge(id).status, 'candidate', 'status must be candidate after nominate')
+})
+
+test('E2E knowledge: POST /knowledge/:id/approve transitions candidate → approved (200)', async () => {
+  const id = makeCandidate('A-approve')
+  await fetch(`${baseUrl}/knowledge/${id}/nominate`, { method: 'POST', headers: authHeaders() })
+
+  const res = await fetch(`${baseUrl}/knowledge/${id}/approve`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'e2e approval' }),
+  })
+  assert.equal(res.status, 200, 'approve must return 200')
+  assert.equal(selectKnowledge(id).status, 'approved', 'status must be approved')
+})
+
+test('E2E knowledge: POST /knowledge/:id/revoke transitions approved → rejected (200)', async () => {
+  const id = makeCandidate('A-revoke')
+  await fetch(`${baseUrl}/knowledge/${id}/nominate`, { method: 'POST', headers: authHeaders() })
+  await fetch(`${baseUrl}/knowledge/${id}/approve`, { method: 'POST', headers: authHeaders(), body: '{}' })
+
+  const res = await fetch(`${baseUrl}/knowledge/${id}/revoke`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'e2e revoke' }),
+  })
+  assert.equal(res.status, 200, 'revoke must return 200')
+  assert.equal(selectKnowledge(id).status, 'rejected', 'status must be rejected')
+})
+
+test('E2E knowledge: POST /knowledge/:id/reject transitions draft → rejected (200)', async () => {
+  const id = makeCandidate('A-reject-from-draft')
+  const res = await fetch(`${baseUrl}/knowledge/${id}/reject`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'e2e reject from draft' }),
+  })
+  assert.equal(res.status, 200, 'reject must return 200')
+  assert.equal(selectKnowledge(id).status, 'rejected', 'status must be rejected')
+})
+
+test('E2E knowledge: POST /knowledge/:id/restore creates new draft with supersedes_id (201)', async () => {
+  const id = makeCandidate('A-restore')
+  await fetch(`${baseUrl}/knowledge/${id}/reject`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'pre-restore reject' }),
+  })
+
+  const res = await fetch(`${baseUrl}/knowledge/${id}/restore`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'e2e restore' }),
+  })
+  assert.equal(res.status, 201, 'restore must return 201 Created')
+  const { id: newId } = (await res.json()) as { id: number }
+  assert.ok(newId > id, 'restored row must have new id')
+
+  const restored = selectKnowledge(newId)
+  assert.equal(restored.status, 'draft', 'restored row must be draft')
+  assert.equal(restored.supersedes_id, id, 'supersedes_id must point to original rejected row')
+})
+
+// =============================================================================
+// Group B — Illegal transitions (INVALID_STATE → 409)
+// =============================================================================
+
+test('E2E knowledge: nominate on approved item returns 409 INVALID_STATE', async () => {
+  const id = makeCandidate('B-illegal-nominate')
+  await fetch(`${baseUrl}/knowledge/${id}/nominate`, { method: 'POST', headers: authHeaders() })
+  await fetch(`${baseUrl}/knowledge/${id}/approve`, { method: 'POST', headers: authHeaders(), body: '{}' })
+
+  const res = await fetch(`${baseUrl}/knowledge/${id}/nominate`, {
+    method: 'POST', headers: authHeaders(),
+  })
+  assert.equal(res.status, 409, 'illegal nominate (approved → candidate) must return 409')
+  const body = (await res.json()) as { error: string }
+  assert.equal(body.error, 'INVALID_STATE', 'error code must be INVALID_STATE')
+})
+
+test('E2E knowledge: approve on draft item returns 409 INVALID_STATE', async () => {
+  const id = makeCandidate('B-illegal-approve')
+  const res = await fetch(`${baseUrl}/knowledge/${id}/approve`, {
+    method: 'POST', headers: authHeaders(), body: '{}',
+  })
+  assert.equal(res.status, 409, 'illegal approve (draft → approved) must return 409')
+  const body = (await res.json()) as { error: string }
+  assert.equal(body.error, 'INVALID_STATE')
+})
+
+test('E2E knowledge: revoke on draft item returns 409 INVALID_STATE', async () => {
+  const id = makeCandidate('B-illegal-revoke')
+  const res = await fetch(`${baseUrl}/knowledge/${id}/revoke`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'illegal revoke' }),
+  })
+  assert.equal(res.status, 409, 'illegal revoke (draft → rejected) must return 409')
+  const body = (await res.json()) as { error: string }
+  assert.equal(body.error, 'INVALID_STATE')
+})
+
+test('E2E knowledge: reject on approved item returns 409 INVALID_STATE', async () => {
+  const id = makeCandidate('B-illegal-reject')
+  await fetch(`${baseUrl}/knowledge/${id}/nominate`, { method: 'POST', headers: authHeaders() })
+  await fetch(`${baseUrl}/knowledge/${id}/approve`, { method: 'POST', headers: authHeaders(), body: '{}' })
+
+  const res = await fetch(`${baseUrl}/knowledge/${id}/reject`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'illegal reject' }),
+  })
+  assert.equal(res.status, 409, 'illegal reject (approved → rejected via /reject) must return 409')
+  const body = (await res.json()) as { error: string }
+  assert.equal(body.error, 'INVALID_STATE')
+})
+
+// =============================================================================
+// Group C — compare-and-swap lost-update prevention
+// =============================================================================
+
+test('E2E knowledge: concurrent nominate on same draft — only one succeeds (CAS)', async () => {
+  const id = makeCandidate('C-cas-nominate')
+
+  // Fire two nominate calls concurrently. better-sqlite3 serializes via
+  // BEGIN IMMEDIATE write lock, so the second one observes status='candidate'
+  // and the CAS condition (`WHERE id=? AND status='draft'`) matches 0 rows →
+  // INVALID_STATE 409.
+  const [resA, resB] = await Promise.all([
+    fetch(`${baseUrl}/knowledge/${id}/nominate`, { method: 'POST', headers: authHeaders() }),
+    fetch(`${baseUrl}/knowledge/${id}/nominate`, { method: 'POST', headers: authHeaders() }),
+  ])
+  const statuses = [resA.status, resB.status].sort((a, b) => a - b)
+  assert.deepEqual(statuses, [200, 409], 'exactly one nominate must succeed, the other must 409')
+  assert.equal(selectKnowledge(id).status, 'candidate', 'final status must be candidate')
+})
+
+// =============================================================================
+// Group D — audit event 박제 검증
+// =============================================================================
+
+test('E2E knowledge: nominate emits knowledge.candidate_nominated audit event', async () => {
+  const id = makeCandidate('D-audit-nominate')
+  await fetch(`${baseUrl}/knowledge/${id}/nominate`, { method: 'POST', headers: authHeaders() })
+
+  const evt = await findAuditEvent('knowledge.candidate_nominated', id)
+  assert.ok(evt, `expected knowledge.candidate_nominated event for resource ${id}`)
+  const payload = JSON.parse(evt.payload) as { from_status: string; to_status: string }
+  assert.equal(payload.from_status, 'draft')
+  assert.equal(payload.to_status, 'candidate')
+})
+
+test('E2E knowledge: approve emits knowledge.candidate_approved audit event', async () => {
+  const id = makeCandidate('D-audit-approve')
+  await fetch(`${baseUrl}/knowledge/${id}/nominate`, { method: 'POST', headers: authHeaders() })
+  await fetch(`${baseUrl}/knowledge/${id}/approve`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'audit-test approve' }),
+  })
+
+  const evt = await findAuditEvent('knowledge.candidate_approved', id)
+  assert.ok(evt, `expected knowledge.candidate_approved event for resource ${id}`)
+  const payload = JSON.parse(evt.payload) as { from_status: string; to_status: string; reason: string }
+  assert.equal(payload.to_status, 'approved')
+  assert.equal(payload.reason, 'audit-test approve')
+})
+
+test('E2E knowledge: restore emits knowledge.restored_from_rejected audit event', async () => {
+  const id = makeCandidate('D-audit-restore')
+  await fetch(`${baseUrl}/knowledge/${id}/reject`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'pre-restore' }),
+  })
+  const restoreRes = await fetch(`${baseUrl}/knowledge/${id}/restore`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'audit-test restore' }),
+  })
+  const { id: newId } = (await restoreRes.json()) as { id: number }
+
+  const evt = await findAuditEvent('knowledge.restored_from_rejected', newId)
+  assert.ok(evt, `expected knowledge.restored_from_rejected event for resource ${newId}`)
+  const payload = JSON.parse(evt.payload) as { original_id: number; new_id: number }
+  assert.equal(payload.original_id, id, 'audit payload must record original rejected id')
+  assert.equal(payload.new_id, newId, 'audit payload must record new draft id')
+})
+
+// =============================================================================
+// Group E — is_active sync + supersedes_id chain
+// =============================================================================
+
+test('E2E knowledge: approve sets is_active=1, revoke sets is_active=0', async () => {
+  const id = makeCandidate('E-is-active')
+  await fetch(`${baseUrl}/knowledge/${id}/nominate`, { method: 'POST', headers: authHeaders() })
+  await fetch(`${baseUrl}/knowledge/${id}/approve`, { method: 'POST', headers: authHeaders(), body: '{}' })
+
+  assert.equal(selectKnowledge(id).is_active, 1, 'approved row must have is_active=1')
+
+  await fetch(`${baseUrl}/knowledge/${id}/revoke`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'flip is_active' }),
+  })
+  assert.equal(selectKnowledge(id).is_active, 0, 'revoked row must have is_active=0')
+})
+
+test('E2E knowledge: rejected from draft sets is_active=0; restore creates new active draft', async () => {
+  const id = makeCandidate('E-supersedes-chain')
+  await fetch(`${baseUrl}/knowledge/${id}/reject`, {
+    method: 'POST', headers: authHeaders(),
+    body: JSON.stringify({ reason: 'chain reject' }),
+  })
+  assert.equal(selectKnowledge(id).is_active, 0, 'rejected row must have is_active=0')
+
+  const restoreRes = await fetch(`${baseUrl}/knowledge/${id}/restore`, {
+    method: 'POST', headers: authHeaders(), body: '{}',
+  })
+  const { id: newId } = (await restoreRes.json()) as { id: number }
+
+  const restored = selectKnowledge(newId)
+  assert.equal(restored.status, 'draft', 'restored row must be status=draft')
+  assert.equal(restored.is_active, 1, 'restored draft row must have is_active=1 (default)')
+  assert.equal(restored.supersedes_id, id, 'supersedes_id must point to the original rejected id')
+
+  // The original row stays immutable (rejected, is_active=0)
+  const original = selectKnowledge(id)
+  assert.equal(original.status, 'rejected', 'original row must remain rejected after restore')
+  assert.equal(original.is_active, 0, 'original row must remain is_active=0 after restore')
+})

--- a/packages/server/src/middleware/error.ts
+++ b/packages/server/src/middleware/error.ts
@@ -12,6 +12,7 @@ const CODE_TO_HTTP: Record<string, number> = {
   [ErrorCode.NOT_FOUND]: 404,
   [ErrorCode.CONFLICT]: 409,
   [ErrorCode.HITL_REQUIRED]: 409,
+  [ErrorCode.INVALID_STATE]: 409,
   [ErrorCode.POLICY_OVERFLOW]: 500,
   [ErrorCode.VALIDATION]: 400,
 }


### PR DESCRIPTION
## Summary

CSR #761 Phase 1 — backend e2e regression lock for Knowledge HITL lifecycle + Audit chain integrity. PR #38 (v0.5.1)에서 노출된 dead code 패턴 (`hitl_trigger.axes` 오해석 + UI gate 조건) 재발 방지가 목적.

- **Phase 1.A** `rest-knowledge-flow.e2e.test.ts` — 신규 15 tests / 5 그룹
- **Phase 1.B** `rest-audit-integrity.e2e.test.ts` — 신규 3 tests (NEW 분리 — 기존 `rest-audit-chain.e2e.test.ts` 0 lines touch 회귀 방지)
- **동반 surgical fix 2건** — 테스트가 진짜 Red→Green 사이클을 거치도록 latent bug 처리

## Phase 0에서 노출된 latent bug 2건 (둘 다 fix 포함, atomic)

1. **`middleware/error.ts` — INVALID_STATE → HTTP 매핑 누락**
   `CODE_TO_HTTP`에 `[ErrorCode.INVALID_STATE]` 부재 → `?? 500` fallback. Knowledge state machine illegal transition (예: approved → candidate)이 4xx가 아닌 silent 500으로 처리됨. 1-line 추가.

2. **`core/knowledge/retriever.ts` — transitionStatus double-ROLLBACK**
   `db.exec('BEGIN IMMEDIATE') → try { … if (changes !== 1) { db.exec('ROLLBACK'); throw … } } catch (e) { db.exec('ROLLBACK'); throw e }` 패턴이 INVALID_STATE 경로에서 두 번 ROLLBACK 호출. 두 번째 ROLLBACK이 SQLite "cannot rollback - no transaction is active" 에러를 raise해 원본 `CodedError`가 마스킹됨 → middleware가 500 fallthrough. inner ROLLBACK 제거 (outer catch가 처리).

## Test coverage

| 그룹 | Tests | 검증 내용 |
|------|:-----:|----------|
| A — Happy 5 transitions | 5 | nominate / approve / revoke / reject / restore — 200·201 + status 검증 |
| B — Illegal → 409 | 4 | nominate(approved) · approve(draft) · revoke(draft) · reject(approved) — `INVALID_STATE` 코드 검증 |
| C — Concurrent CAS | 1 | `Promise.all` 동시 nominate → `[200, 409]` deepEqual (BEGIN IMMEDIATE 직렬화) |
| D — Audit 박제 | 3 | `knowledge.candidate_nominated` · `candidate_approved` · `restored_from_rejected` event_type + resource_id + payload.from/to_status 검증 |
| E — is_active + supersedes | 2 | approve→1 / revoke→0 / restore 신규 draft `supersedes_id` 체인 |
| Audit integrity | 3 | `original_hash_type='redaction_pre'` 박제 · sk-token + token key redaction + chain valid · prev_hash 변조 → 409 broken[linkage] + 복원 |

## Test plan

- [x] `pnpm --filter @gijun-ai/server test` — 100 total · 97 PASS · 3 FAIL (pre-existing C1 HMAC, main 동일)
- [x] `pnpm --filter @gijun-ai/core test` — 124/124 PASS (retriever.ts 변경 회귀 0)
- [x] `tsc -p tsconfig.test.json --noEmit` — No errors
- [x] git stash로 main branch 비교 — 3 C1 실패 pre-existing 확인
- [ ] Biome lint — 환경 OOM (`[warn] Linter process terminated abnormally (possibly out of memory)`), TypeScript 컴파일은 clean. 별도 환경 점검 필요

## Scope

- Phase 1 (Knowledge + Audit) — 본 PR
- Phase 2 (External sync), Phase 3 (Budget), Phase 4 (Step HITL) — 후속 PR
- Coverage 도구 (c8/nyc) — 별건 CSR
- CSR #755 (Decision-2 hotfix) 와 독립

## Refs

- CSR http://192.168.200.125:3000/csr/761
- prompt_plan.md (Phase 1 plan + DoD)
- claude_learn #190 (학습 박제 — UI 작성 전 backend contract 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)