### PR TITLE
test: CSR #791 (CSR #761 Phase 2) — External sync E2E (4 tests)

### DIFF
--- a/packages/server/src/__tests__/rest-external-sync.e2e.test.ts
+++ b/packages/server/src/__tests__/rest-external-sync.e2e.test.ts
@@ -1,0 +1,146 @@
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { Server } from 'node:http'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+process.env['GIJUN_DB_PATH'] = ':memory:'
+process.env['GIJUN_MIGRATIONS_PATH'] = resolve(__dirname, '../../../../migrations')
+process.env['AGENTGUARD_TOKEN'] = 'test-token-external-sync'
+
+const { createApp } = await import('../app.js')
+const core = await import('@gijun-ai/core')
+
+const TOKEN = 'test-token-external-sync'
+let server: Server
+let baseUrl: string
+
+function authHeaders(): Record<string, string> {
+  return { 'Content-Type': 'application/json', 'X-AgentGuard-Token': TOKEN }
+}
+
+type ExternalSyncBody = {
+  externalSource: string
+  externalId: string
+  title: string
+  description?: string
+  status?: 'pending' | 'in_progress' | 'done' | 'cancelled'
+}
+
+async function postExternal(body: ExternalSyncBody): Promise<{ status: number; body: { id: number; created: boolean } }> {
+  const res = await fetch(`${baseUrl}/tasks/external`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  })
+  const json = (await res.json()) as { id: number; created: boolean }
+  return { status: res.status, body: json }
+}
+
+type AuditTailRow = {
+  id: number
+  event_type: string
+  resource_id: string | null
+  payload: string
+}
+
+async function findAuditEvent(
+  eventType: string,
+  resourceId: number,
+): Promise<AuditTailRow | undefined> {
+  const res = await fetch(`${baseUrl}/audit?n=200`, { headers: authHeaders() })
+  assert.equal(res.status, 200, 'audit tail must return 200')
+  const events = (await res.json()) as AuditTailRow[]
+  return events.find(
+    (e) => e.event_type === eventType && e.resource_id === String(resourceId),
+  )
+}
+
+before(async () => {
+  core.runMigrations()
+  const app = createApp()
+  await new Promise<void>((resolvePromise) => {
+    server = app.listen(0, '127.0.0.1', () => resolvePromise())
+  })
+  const addr = server.address()
+  if (typeof addr !== 'object' || addr === null) throw new Error('unexpected address')
+  baseUrl = `http://127.0.0.1:${addr.port}`
+})
+
+after(async () => {
+  await new Promise<void>((resolvePromise) => {
+    server.close(() => resolvePromise())
+  })
+  core.closeDb()
+  delete process.env['GIJUN_DB_PATH']
+  delete process.env['GIJUN_MIGRATIONS_PATH']
+  delete process.env['AGENTGUARD_TOKEN']
+})
+
+test('E2E external-sync: first upsert returns 201 + created=true', async () => {
+  const { status, body } = await postExternal({
+    externalSource: 'csr-bulletin',
+    externalId: 'csr-1001-first',
+    title: 'first external task',
+  })
+  assert.equal(status, 201, 'first upsert must return 201 Created')
+  assert.equal(body.created, true, 'first upsert must report created=true')
+  assert.ok(body.id > 0, 'first upsert must return a positive task id')
+})
+
+test('E2E external-sync: same (externalSource, externalId) returns 200 + created=false (idempotent)', async () => {
+  const payload = {
+    externalSource: 'csr-bulletin',
+    externalId: 'csr-1002-idempotent',
+    title: 'idempotent external task',
+  }
+  const first = await postExternal(payload)
+  assert.equal(first.status, 201, 'first call must return 201')
+  assert.equal(first.body.created, true, 'first call must report created=true')
+
+  const second = await postExternal(payload)
+  assert.equal(second.status, 200, 'second call (same pair) must return 200 OK (idempotent)')
+  assert.equal(second.body.created, false, 'second call must report created=false')
+  assert.equal(second.body.id, first.body.id, 'idempotent call must reuse the same task id')
+})
+
+test('E2E external-sync: same externalId across different externalSource creates distinct rows (partial unique index)', async () => {
+  const sharedId = 'shared-external-id-001'
+  const a = await postExternal({
+    externalSource: 'system-a',
+    externalId: sharedId,
+    title: 'task in system-a',
+  })
+  const b = await postExternal({
+    externalSource: 'system-b',
+    externalId: sharedId,
+    title: 'task in system-b',
+  })
+  assert.equal(a.status, 201, 'system-a first call must return 201')
+  assert.equal(b.status, 201, 'system-b first call (different source) must also return 201')
+  assert.equal(a.body.created, true)
+  assert.equal(b.body.created, true)
+  assert.notEqual(a.body.id, b.body.id, 'different externalSource must yield distinct task rows')
+})
+
+test('E2E external-sync: insert path emits task.external_sync audit event with externalSource/Id payload', async () => {
+  const { status, body } = await postExternal({
+    externalSource: 'audit-source',
+    externalId: 'audit-id-001',
+    title: 'audit-traced external task',
+  })
+  assert.equal(status, 201)
+
+  const evt = await findAuditEvent('task.external_sync', body.id)
+  assert.ok(evt, `expected task.external_sync event for resource ${body.id}`)
+  const payload = JSON.parse(evt.payload) as {
+    externalSource: string
+    externalId: string
+    created?: boolean
+  }
+  assert.equal(payload.externalSource, 'audit-source')
+  assert.equal(payload.externalId, 'audit-id-001')
+  assert.equal(payload.created, true, 'insert-path audit payload must record created=true')
+})


### PR DESCRIPTION
## Summary

CSR #761 후속 Phase 2 — Phase 1 (PR #46 MERGED) 패턴 답습 + tasks 도메인. POST /tasks/external 의 4 시나리오 HTTP layer 잠금.

- **4 tests** in `rest-external-sync.e2e.test.ts` — 단일 신규 파일 (소규모, 1 파일 / API 변경 없음 / 코드 변경 없음, /plan 미트리거)

## Test scenarios

| # | 시나리오 | 검증 |
|:-:|---------|------|
| 1 | first upsert | 201 + `created=true` |
| 2 | idempotent (same source+id) | 200 + `created=false` + same `id` |
| 3 | partial unique index | 다른 source 같은 id → 두 distinct row, 모두 201 |
| 4 | audit event | `task.external_sync` event_type + resource_id + payload.externalSource/Id/created=true |

## Test plan

- [x] `pnpm --filter @gijun-ai/server test` — 104 total / 101 PASS / 3 FAIL (pre-existing C1 HMAC, CSR #789)
- [x] TypeScript compile clean
- [x] @gijun-ai/core 변경 없음 → 회귀 무관
- [x] Phase 1 boilerplate 답습 (process.env / before / after / authHeaders / findAuditEvent)
- [ ] CI green (자동 확인)

## Pattern alignment with Phase 1 (PR #46)

같은 boilerplate · `findAuditEvent` helper · UNIT vs E2E G-5 CDP 3축 다름 (인터페이스 / 결과 / 부수효과).

## Refs

- CSR #791: http://192.168.200.125:3000/csr/791
- CSR #761: http://192.168.200.125:3000/csr/761 (본문 Phase 2-5 명시)
- Phase 1 PR #46 (MERGED, commit fe34df1) — 답습 reference
- 후속 PR: Phase 3 (Budget 7 상태) · Phase 4 (Step HITL 5 reason)

🤖 Generated with [Claude Code](https://claude.com/claude-code)