### PR TITLE
test: CSR #793 (CSR #761 Phase 4) — evaluateStepHitl 5 reason UNIT (8 tests)

### DIFF
--- a/packages/core/src/__tests__/evaluate-step-hitl.test.ts
+++ b/packages/core/src/__tests__/evaluate-step-hitl.test.ts
@@ -1,0 +1,93 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { evaluateStepHitl, type ActionContext, type HitlTrigger } from '../hitl/gate.js'
+
+// Covers the 5 trigger reasons of evaluateStepHitl in priority order:
+//   irreversible > blast_radius > complexity > verify_fail > low_confidence
+// CSR #761 Phase 4 (CSR #793) — CSR body asked for E2E but no HTTP endpoint
+// exposes evaluateStepHitl; UNIT coverage is the actual gap.
+
+test('evaluateStepHitl: returns irreversible trigger for action containing "DROP TABLE"', () => {
+  const ctx: ActionContext = { action: 'DROP TABLE users CASCADE' }
+  const trigger = evaluateStepHitl(ctx)
+  assert.ok(trigger, 'must return a trigger, not null')
+  assert.equal(trigger.reason, 'irreversible')
+  assert.equal((trigger as Extract<HitlTrigger, { reason: 'irreversible' }>).pattern, 'DROP TABLE')
+})
+
+test('evaluateStepHitl: irreversible matches case-insensitively (lowercase action)', () => {
+  // The implementation upper-cases both sides, so lower-case action text
+  // containing the pattern still matches.
+  const trigger = evaluateStepHitl({ action: 'sudo rm -rf /tmp/cache' })
+  assert.ok(trigger)
+  assert.equal(trigger.reason, 'irreversible')
+  assert.equal((trigger as Extract<HitlTrigger, { reason: 'irreversible' }>).pattern, 'rm -rf')
+})
+
+test('evaluateStepHitl: returns blast_radius trigger when blastRadius=external (and no irreversible match)', () => {
+  const trigger = evaluateStepHitl({
+    action: 'POST to upstream payment provider',
+    blastRadius: 'external',
+  })
+  assert.ok(trigger)
+  assert.equal(trigger.reason, 'blast_radius')
+  assert.equal((trigger as Extract<HitlTrigger, { reason: 'blast_radius' }>).scope, 'external')
+})
+
+test('evaluateStepHitl: returns complexity trigger when complexity=critical (and no higher-priority match)', () => {
+  const trigger = evaluateStepHitl({
+    action: 'refactor auth module',
+    complexity: 'critical',
+  })
+  assert.ok(trigger)
+  assert.equal(trigger.reason, 'complexity')
+  assert.equal((trigger as Extract<HitlTrigger, { reason: 'complexity' }>).level, 'critical')
+})
+
+test('evaluateStepHitl: returns verify_fail trigger when verifyVerdict=fail', () => {
+  const trigger = evaluateStepHitl({
+    action: 'commit code',
+    verifyVerdict: 'fail',
+  })
+  assert.ok(trigger)
+  assert.equal(trigger.reason, 'verify_fail')
+  assert.equal((trigger as Extract<HitlTrigger, { reason: 'verify_fail' }>).verdict, 'fail')
+})
+
+test('evaluateStepHitl: returns low_confidence trigger when verifyConfidence < 0.7', () => {
+  const trigger = evaluateStepHitl({
+    action: 'apply migration',
+    verifyConfidence: 0.65,
+  })
+  assert.ok(trigger)
+  assert.equal(trigger.reason, 'low_confidence')
+  assert.equal(
+    (trigger as Extract<HitlTrigger, { reason: 'low_confidence' }>).confidence,
+    0.65,
+  )
+})
+
+test('evaluateStepHitl: priority — irreversible beats blast_radius+complexity+verify_fail+low_confidence on the same context', () => {
+  // All five conditions are satisfied; the implementation picks irreversible
+  // first because the action matches an IRREVERSIBLE_PATTERN.
+  const trigger = evaluateStepHitl({
+    action: 'DELETE FROM tasks WHERE id < 1000',
+    blastRadius: 'external',
+    complexity: 'critical',
+    verifyVerdict: 'fail',
+    verifyConfidence: 0.1,
+  })
+  assert.ok(trigger)
+  assert.equal(trigger.reason, 'irreversible', 'irreversible must win over all other reasons')
+})
+
+test('evaluateStepHitl: returns null when no condition triggers HITL', () => {
+  const trigger = evaluateStepHitl({
+    action: 'read user profile',
+    complexity: 'trivial',
+    blastRadius: 'local',
+    verifyVerdict: 'pass',
+    verifyConfidence: 0.95,
+  })
+  assert.equal(trigger, null, 'safe context must return null (no HITL required)')
+})


### PR DESCRIPTION
## Summary

CSR #761 후속 Phase 4 — 마지막 Phase. CSR 본문은 "step-level e2e 5 reason"을 요구했으나 **evaluateStepHitl 은 HTTP endpoint 미노출** → E2E 작성 불가. 사용자 결정으로 UNIT test 변형 (HTTP endpoint 추가는 별건).

- **8 tests** in `packages/core/src/__tests__/evaluate-step-hitl.test.ts` — core UNIT, 1 신규 파일

## Test scenarios (5 reason + priority + null)

| # | 시나리오 | 검증 |
|:-:|---------|------|
| 1 | irreversible (uppercase) | action='DROP TABLE users CASCADE' → reason='irreversible', pattern='DROP TABLE' |
| 2 | irreversible (lowercase) | action='sudo rm -rf /tmp/cache' → case-insensitive match |
| 3 | blast_radius | blastRadius='external' → reason='blast_radius', scope='external' |
| 4 | complexity | complexity='critical' → reason='complexity', level='critical' |
| 5 | verify_fail | verifyVerdict='fail' → reason='verify_fail', verdict='fail' |
| 6 | low_confidence | verifyConfidence=0.65 → reason='low_confidence', confidence=0.65 |
| 7 | priority | 5 conditions all satisfied → irreversible wins |
| 8 | null | safe context (trivial/local/pass/0.95) → null |

## Phase 4 spec mismatch 발견

CSR #761 본문: "기존 e2e는 task-level만 cover. step-level (`evaluateStepHitl`)의 5 reason 각각 검증"

실제 코드:
- `evaluateStepHitl` core 함수 ✓ 구현됨 (`hitl/gate.ts:41`)
- **HTTP endpoint 부재** — POST /:id/steps는 `addTaskStep` 만 호출, `evaluateStepHitl` 호출 안 함
- UNIT test 부재 — `hitl-incomplete-context.test.ts` 는 task-level (`evaluateHitlForTask`) 만

→ E2E 불가, UNIT이 실질 gap. HTTP endpoint 추가 spec은 별건 CSR.

## Test plan

- [x] `pnpm --filter @gijun-ai/core test` — 132 total / 132 PASS (124 기존 + 8 신규 회귀 0)
- [x] TypeScript compile clean
- [x] @gijun-ai/server 변경 없음 → 회귀 무관
- [ ] CI green (자동 확인)

## Refs

- CSR #793: http://192.168.200.125:3000/csr/793
- CSR #761: http://192.168.200.125:3000/csr/761 (마지막 Phase)
- Phase 1·2·3 PR #46·#47·#48 모두 MERGED

🤖 Generated with [Claude Code](https://claude.com/claude-code)